### PR TITLE
Bump garmadon dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
         <netty-all.version>4.1.30.Final</netty-all.version>
         <bytebuddy.version>1.9.2</bytebuddy.version>
-        <spark.version>2.2.2</spark.version>
+        <spark.version>2.3.2</spark.version>
         <es.version>6.3.2</es.version>
         <logback.version>1.2.3</logback.version>
         <prometheus.version>0.5.0</prometheus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,14 +76,14 @@
     <properties>
         <garmadon.version>1.0.0</garmadon.version>
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
-        <netty-all.version>4.1.29.Final</netty-all.version>
-        <bytebuddy.version>1.8.22</bytebuddy.version>
+        <netty-all.version>4.1.30.Final</netty-all.version>
+        <bytebuddy.version>1.9.2</bytebuddy.version>
         <spark.version>2.2.2</spark.version>
         <es.version>6.3.2</es.version>
         <logback.version>1.2.3</logback.version>
         <prometheus.version>0.5.0</prometheus.version>
         <maria-java-client.version>2.2.6</maria-java-client.version>
-        <oshi.version>3.8.3</oshi.version>
+        <oshi.version>3.9.1</oshi.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <slf4j.version>1.7.25</slf4j.version>
         <protobuf.version>2.5.0</protobuf.version>

--- a/scripts/launch_docker_platform.sh
+++ b/scripts/launch_docker_platform.sh
@@ -22,6 +22,10 @@ docker-compose down
 
 # Start containers
 docker-compose up --build -d
+
+# Get spark and hadoop release
+HADOOP_VERSION=$(grep "ENV HADOOP_VERSION" garmadon/Dockerfile|cut -d= -f2)
+SPARK_VERSION=$(grep "ENV SPARK_VERSION" garmadon/Dockerfile|cut -d= -f2)
 popd
 
 # Create garmadon ES template
@@ -58,31 +62,31 @@ pushd ${DOCKER_COMPOSE_FOLDER}
 docker-compose exec client java -version
 
 # MapRed Teragen
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-2.6.0-cdh5.15.0.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
     teragen 1000000 /tmp/test/teragen
 
 # MapRed Terasort
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-2.6.0-cdh5.15.0.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
     terasort /tmp/test/teragen /tmp/test/terasort
 
 # MapRed Pi
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-2.6.0-cdh5.15.0.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
     pi 2 1000
 
 # SparkPi (Compute)
 docker-compose exec client /opt/spark/bin/spark-submit --class org.apache.spark.examples.SparkPi \
-    /opt/spark/examples/jars/spark-examples_2.11-2.2.2.jar 100
+    /opt/spark/examples/jars/spark-examples_2.11-${SPARK_VERSION}.jar 100
 
 # Spark DFSReadWriteTest (Read/Write/Shuffle)
 docker-compose exec client /opt/spark/bin/spark-submit --class org.apache.spark.examples.DFSReadWriteTest \
-    /opt/spark/examples/jars/spark-examples_2.11-2.2.2.jar /opt/garmadon/conf-forwarder/server.properties /tmp
+    /opt/spark/examples/jars/spark-examples_2.11-${SPARK_VERSION}.jar /opt/garmadon/conf-forwarder/server.properties /tmp
 
 # Spark SQL (Interact with HDFS and execute lots of stage)
 docker-compose exec client /opt/spark/bin/spark-submit \
     --conf spark.shuffle.service.enabled=true --conf spark.dynamicAllocation.enabled=true \
     --conf spark.dynamicAllocation.minExecutors=1 --conf spark.dynamicAllocation.initialExecutors=4 \
     --conf spark.dynamicAllocation.maxExecutors=4 --conf spark.dynamicAllocation.executorIdleTimeout=1s \
-    --class org.apache.spark.examples.sql.SparkSQLExample /opt/spark/examples/jars/spark-examples_2.11-2.2.2.jar
+    --class org.apache.spark.examples.sql.SparkSQLExample /opt/spark/examples/jars/spark-examples_2.11-${SPARK_VERSION}.jar
 
 # Spark yarn client
 docker-compose exec client /opt/spark/bin/spark-submit \
@@ -90,6 +94,6 @@ docker-compose exec client /opt/spark/bin/spark-submit \
     --conf spark.shuffle.service.enabled=true --conf spark.dynamicAllocation.enabled=true \
     --conf spark.dynamicAllocation.minExecutors=1 --conf spark.dynamicAllocation.initialExecutors=4 \
     --conf spark.dynamicAllocation.maxExecutors=4 --conf spark.dynamicAllocation.executorIdleTimeout=1s \
-    --class org.apache.spark.examples.sql.SparkSQLExample /opt/spark/examples/jars/spark-examples_2.11-2.2.2.jar
+    --class org.apache.spark.examples.sql.SparkSQLExample /opt/spark/examples/jars/spark-examples_2.11-${SPARK_VERSION}.jar
 popd
 popd

--- a/test/src/main/docker/garmadon/Dockerfile
+++ b/test/src/main/docker/garmadon/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH=${JAVA_HOME}/bin:/opt/hadoop/bin:/opt/spark/bin:$PATH
 
 # Environment Version
 ENV HADOOP_VERSION=2.6.0-cdh5.15.0
-ENV SPARK_VERSION=2.2.2
+ENV SPARK_VERSION=2.3.2
 
 # Environment Config
 ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop


### PR DESCRIPTION
Netty from 4.1.29.Final to 4.1.30.Final
 - https://netty.io/news/2018/09/28/4-1-30-Final.html
ByteBuddy from 1.8.22 to 1.9.2
 - https://github.com/raphw/byte-buddy/blob/master/release-notes.md
Oshi from 3.8.3 to 3.9.1
 - https://github.com/oshi/oshi/blob/master/CHANGELOG.md

Change-Id: I788a12ba59ec26b4a9bbc92af2138cabdcbd6662