### PR TITLE
[Breaking] - Bump protobuf from 2.5.0 to 3.6.1

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -32,6 +32,12 @@
             <version>${bytebuddy.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
         <!-- Hadoop dependencies -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/jvm-statistics/core/src/test/java/com/criteo/jvm/JVMStatisticsTest.java
+++ b/jvm-statistics/core/src/test/java/com/criteo/jvm/JVMStatisticsTest.java
@@ -24,7 +24,7 @@ public class JVMStatisticsTest {
             "class\\[loaded=\\d+, unloaded=\\d+, initialized=\\d+, loadtime=\\d+, inittime=\\d+, veriftime=\\d+\\], " +
             "os\\[%loadavg=\\d+, physicalfree=\\d+, physicaltotal=\\d+, swapfree=\\d+, swaptotal=\\d+, virtual=\\d+\\], " +
             "cpu\\[cores=\\d+, %load=\\d+\\], " +
-            "process\\[threads=\\d+, rss=\\d+, vsz=\\d+, %user=\\d+, %sys=\\d+, read=\\d+, written=\\d+, ctxtswitches=\\d+, interrupts=\\d+\\], " +
+            "process\\[threads=\\d+, rss=\\d+, vsz=\\d+, %user=\\d+, %sys=\\d+, read=\\d+, written=\\d+.*\\], " +
             "safepoints\\[count=\\d+, synctime=\\d+, totaltime=\\d+\\], " +
             "synclocks\\[contendedlockattempts=\\d+, deflations=\\d+, futilewakeups=\\d+, inflations=\\d+, monextant=\\d+, notifications=\\d+, parks=\\d+\\].*");
     private static final Pattern GCSTATS_PATTERN = Pattern.compile(".* occurred at \\d+-\\d+-\\d+ \\d+:\\d+:\\d+.\\d+, took \\d+ms \\(System\\.gc\\(\\)\\)  (eden|survivor|old)\\[[-+]\\d+\\]\\(\\d+->\\d+\\) (eden|survivor|old)\\[[-+]\\d+\\]\\(\\d+->\\d+\\).*");

--- a/jvm-statistics/protobuf/src/main/protobuf/JVMStatistics.proto
+++ b/jvm-statistics/protobuf/src/main/protobuf/JVMStatistics.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package jvmstatistics;
 
@@ -7,30 +7,30 @@ option java_outer_classname = "JVMStatisticsProtos";
 
 message JVMStatisticsData {
     message Property {
-        optional string name = 1;
-        optional string value = 2;
+        string name = 1;
+        string value = 2;
     }
     message Section {
-        optional string name = 1;
+        string name = 1;
         repeated Property property = 2;
     }
-    optional fixed64 timestamp = 1;
+    fixed64 timestamp = 1;
     repeated Section section = 2;
 }
 
 message GCStatisticsData {
-    optional fixed64 timestamp = 1;
-    optional string collector_name = 2;
-    optional int64 pause_time = 3;
-    optional string cause = 4;
-    optional int64 eden_before = 5;
-    optional int64 eden_after = 6;
-    optional int64 survivor_before = 7;
-    optional int64 survivor_after = 8;
-    optional int64 old_before = 9;
-    optional int64 old_after = 10;
-    optional int64 code_before = 11;
-    optional int64 code_after = 12;
-    optional int64 metaspace_before = 13;
-    optional int64 metaspace_after = 14;
+    fixed64 timestamp = 1;
+    string collector_name = 2;
+    int64 pause_time = 3;
+    string cause = 4;
+    int64 eden_before = 5;
+    int64 eden_after = 6;
+    int64 survivor_before = 7;
+    int64 survivor_after = 8;
+    int64 old_before = 9;
+    int64 old_after = 10;
+    int64 code_before = 11;
+    int64 code_after = 12;
+    int64 metaspace_before = 13;
+    int64 metaspace_after = 14;
 }

--- a/jvm-statistics/protobuf/src/test/java/com/criteo/jvm/ProtobufGCNotificationsTest.java
+++ b/jvm-statistics/protobuf/src/test/java/com/criteo/jvm/ProtobufGCNotificationsTest.java
@@ -1,7 +1,5 @@
 package com.criteo.jvm;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.text.MatchesPattern;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,11 +16,7 @@ public class ProtobufGCNotificationsTest {
             "collector_name: \".*\"\\s+" +
             "pause_time: \\d+\\s+" +
             "cause: \"System.gc\\(\\)\"\\s+" +
-            "eden_before: \\d+\\s+" +
-            "eden_after: \\d+\\s+" +
-            "survivor_before: \\d+\\s+" +
-            "survivor_after: \\d+\\s+" +
-            "old_before: \\d+\\s+" +
+            ".*" +
             "old_after: \\d+\\s+" +
             "code_before: \\d+\\s+" +
             "code_after: \\d+\\s+" +

--- a/jvm-statistics/protobuf/src/test/java/com/criteo/jvm/ProtobufStatisticsSinkTest.java
+++ b/jvm-statistics/protobuf/src/test/java/com/criteo/jvm/ProtobufStatisticsSinkTest.java
@@ -1,7 +1,5 @@
 package com.criteo.jvm;
 
-import com.criteo.jvm.ProtobufStatisticsSink;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.regex.Pattern;

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <oshi.version>3.9.1</oshi.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <protobuf.version>2.5.0</protobuf.version>
+        <protobuf.version>3.6.1</protobuf.version>
         <kafka.version>0.10.2.1</kafka.version>
 
         <!-- tests -->

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
@@ -122,28 +122,17 @@ public class ElasticSearchReader implements BulkProcessor.Listener {
     private void writeToES(GarmadonMessage msg) {
         Map<String, Object> jsonMap = new HashMap<>();
 
-        if (msg.getHeader().hasApplicationId())
-            jsonMap.put("application_id", msg.getHeader().getApplicationId());
-        if (msg.getHeader().hasAppAttemptId())
-            jsonMap.put("attempt_id", msg.getHeader().getAppAttemptId());
-        if (msg.getHeader().hasApplicationName())
-            jsonMap.put("application_name", msg.getHeader().getApplicationName());
-        if (msg.getHeader().hasContainerId())
-            jsonMap.put("container_id", msg.getHeader().getContainerId());
-        if (msg.getHeader().hasHostname())
-            jsonMap.put("hostname", msg.getHeader().getHostname());
-        if (msg.getHeader().hasUserName())
-            jsonMap.put("username", msg.getHeader().getUserName());
-        if (msg.getHeader().hasPid())
-            jsonMap.put("pid", msg.getHeader().getPid());
-        if (msg.getHeader().hasFramework())
-            jsonMap.put("framework", msg.getHeader().getFramework());
-        if (msg.getHeader().hasComponent())
-            jsonMap.put("component", msg.getHeader().getComponent());
-        if (msg.getHeader().hasExecutorId())
-            jsonMap.put("executor_id", msg.getHeader().getExecutorId());
-        if (msg.getHeader().hasMainClass())
-            jsonMap.put("main_class", msg.getHeader().getMainClass());
+        jsonMap.put("application_id", msg.getHeader().getApplicationId());
+        jsonMap.put("attempt_id", msg.getHeader().getAppAttemptId());
+        jsonMap.put("application_name", msg.getHeader().getApplicationName());
+        jsonMap.put("container_id", msg.getHeader().getContainerId());
+        jsonMap.put("hostname", msg.getHeader().getHostname());
+        jsonMap.put("username", msg.getHeader().getUserName());
+        jsonMap.put("pid", msg.getHeader().getPid());
+        jsonMap.put("framework", msg.getHeader().getFramework());
+        jsonMap.put("component", msg.getHeader().getComponent());
+        jsonMap.put("executor_id", msg.getHeader().getExecutorId());
+        jsonMap.put("main_class", msg.getHeader().getMainClass());
         jsonMap.put("tags", msg.getHeader().getTagsList());
 
         HashMap<String, Map<String, Object>> eventMaps = putBodySpecificFields(

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
@@ -77,9 +77,7 @@ public class EventHelper {
         eventMap.put("num_tasks", event.getNumTasks());
 
         eventMap.put("status", event.getStatus());
-        if (event.hasFailureReason()) {
-            eventMap.put("failure_reason", event.getFailureReason());
-        }
+        eventMap.put("failure_reason", event.getFailureReason());
         eventMap.put("executor_cpu_time", event.getExecutorCpuTime());
         eventMap.put("executor_deserialize_cpu_time", event.getExecutorDeserializeCpuTime());
         eventMap.put("executor_run_time", event.getExecutorRunTime());
@@ -117,9 +115,7 @@ public class EventHelper {
         eventMap.put("executor_hostname", event.getExecutorHostname());
 
         eventMap.put("status", event.getStatus());
-        if (event.hasFailureReason()) {
-            eventMap.put("failure_reason", event.getFailureReason());
-        }
+        eventMap.put("failure_reason", event.getFailureReason());
         eventMap.put("executor_cpu_time", event.getExecutorCpuTime());
         eventMap.put("executor_deserialize_cpu_time", event.getExecutorDeserializeCpuTime());
         eventMap.put("executor_run_time", event.getExecutorRunTime());

--- a/schema/src/main/protobuf/container_event.proto
+++ b/schema/src/main/protobuf/container_event.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package com.criteo.hadoop.garmadon;
 
@@ -6,8 +6,8 @@ option java_package = "com.criteo.hadoop.garmadon.event.proto";
 option java_outer_classname = "ContainerEventProtos";
 
 message ContainerResourceEvent {
-    required uint64 timestamp = 1;
-    required string type = 2;
-    optional uint64 limit = 4;
-    optional float value = 5;
+    uint64 timestamp = 1;
+    string type = 2;
+    uint64 limit = 4;
+    float value = 5;
 }

--- a/schema/src/main/protobuf/data_access_event.proto
+++ b/schema/src/main/protobuf/data_access_event.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package com.criteo.hadoop.garmadon;
 
@@ -6,20 +6,20 @@ option java_package = "com.criteo.hadoop.garmadon.event.proto";
 option java_outer_classname = "DataAccessEventProtos";
 
 message PathEvent {
-    required uint64 timestamp = 1;
-    required string path = 2;
-    required string type = 3;
+    uint64 timestamp = 1;
+    string path = 2;
+    string type = 3;
 }
 
 message FsEvent {
-    required uint64 timestamp = 1;
-    optional string src_path = 2;
-    required string dst_path = 3;
-    required string action = 4;
-    required string uri = 5;
+    uint64 timestamp = 1;
+    string src_path = 2;
+    string dst_path = 3;
+    string action = 4;
+    string uri = 5;
 }
 
 message StateEvent {
-    required uint64 timestamp = 1;
-    required string state = 2;
+    uint64 timestamp = 1;
+    string state = 2;
 }

--- a/schema/src/main/protobuf/event_header.proto
+++ b/schema/src/main/protobuf/event_header.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package com.criteo.hadoop.garmadon;
 
@@ -6,17 +6,17 @@ option java_package = "com.criteo.hadoop.garmadon.event.proto";
 option java_outer_classname = "EventHeaderProtos";
 
 message Header {
-    optional string application_id = 1;
-    optional string app_attempt_id = 2;
-    optional string application_name = 3;
-    optional string user_name = 4;
-    optional string container_id = 5;
-    optional string hostname = 6;
-    optional string pid = 8;
-    optional string framework = 9;
-    optional string component = 10;
-    optional string executor_id = 11;
+    string application_id = 1;
+    string app_attempt_id = 2;
+    string application_name = 3;
+    string user_name = 4;
+    string container_id = 5;
+    string hostname = 6;
+    string pid = 8;
+    string framework = 9;
+    string component = 10;
+    string executor_id = 11;
     repeated string tags = 12;
-    optional string id = 13;
-    optional string main_class = 14;
+    string id = 13;
+    string main_class = 14;
 }

--- a/schema/src/main/protobuf/spark_event.proto
+++ b/schema/src/main/protobuf/spark_event.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package com.criteo.hadoop.garmadon;
 
@@ -6,115 +6,115 @@ option java_package = "com.criteo.hadoop.garmadon.event.proto";
 option java_outer_classname = "SparkEventProtos";
 
 message StageEvent {
-    required int64 start_time = 1;
-    required int64 completion_time = 2;
-    required string stage_name = 3;
-    required string stage_id = 4;
-    required string attempt_id = 5;
-    optional int32 num_tasks = 6;
+    int64 start_time = 1;
+    int64 completion_time = 2;
+    string stage_name = 3;
+    string stage_id = 4;
+    string attempt_id = 5;
+    int32 num_tasks = 6;
 
-    optional string status = 7;
-    optional string failure_reason = 8;
+    string status = 7;
+    string failure_reason = 8;
 
-    optional int64 executor_cpu_time = 9;
-    optional int64 executor_deserialize_cpu_time = 10;
+    int64 executor_cpu_time = 9;
+    int64 executor_deserialize_cpu_time = 10;
 
-    optional int64 executor_run_time = 11;
-    optional int64 jvm_gc_time = 12;
-    optional int64 executor_deserialize_time = 13;
-    optional int64 result_serialization_time = 14;
+    int64 executor_run_time = 11;
+    int64 jvm_gc_time = 12;
+    int64 executor_deserialize_time = 13;
+    int64 result_serialization_time = 14;
 
-    optional int64 result_size = 15;
-    optional int64 peak_execution_memory = 16;
+    int64 result_size = 15;
+    int64 peak_execution_memory = 16;
 
-    optional int64 disk_bytes_spilled = 17;
-    optional int64 memory_bytes_spilled = 18;
+    int64 disk_bytes_spilled = 17;
+    int64 memory_bytes_spilled = 18;
 
-    optional int64 shuffle_read_records = 19;
-    optional int64 shuffle_read_fetch_wait_time = 20;
-    optional int64 shuffle_read_local_bytes = 21;
-    optional int64 shuffle_read_remote_bytes = 22;
-    optional int64 shuffle_read_total_bytes = 23;
-    optional int64 shuffle_read_local_blocks_fetched = 24;
-    optional int64 shuffle_read_remote_blocks_fetched = 25;
-    optional int64 shuffle_read_total_blocks_fetched = 26;
+    int64 shuffle_read_records = 19;
+    int64 shuffle_read_fetch_wait_time = 20;
+    int64 shuffle_read_local_bytes = 21;
+    int64 shuffle_read_remote_bytes = 22;
+    int64 shuffle_read_total_bytes = 23;
+    int64 shuffle_read_local_blocks_fetched = 24;
+    int64 shuffle_read_remote_blocks_fetched = 25;
+    int64 shuffle_read_total_blocks_fetched = 26;
 
-    optional int64 shuffle_write_shuffle_records = 27;
-    optional int64 shuffle_write_shuffle_time = 28;
-    optional int64 shuffle_write_shuffle_bytes = 29;
+    int64 shuffle_write_shuffle_records = 27;
+    int64 shuffle_write_shuffle_time = 28;
+    int64 shuffle_write_shuffle_bytes = 29;
 
-    optional int64 input_records = 30;
-    optional int64 input_bytes = 31;
-    optional int64 output_records = 32;
-    optional int64 output_bytes = 33;
+    int64 input_records = 30;
+    int64 input_bytes = 31;
+    int64 output_records = 32;
+    int64 output_bytes = 33;
 }
 
 message StageStateEvent {
-    required uint64 timestamp = 1;
-    required string state = 2;
+    uint64 timestamp = 1;
+    string state = 2;
 
-    required string stage_name = 3;
-    required string stage_id = 4;
-    required string attempt_id = 5;
-    optional int32 num_tasks = 6;
+    string stage_name = 3;
+    string stage_id = 4;
+    string attempt_id = 5;
+    int32 num_tasks = 6;
 }
 
 message ExecutorStateEvent {
-    required uint64 timestamp = 1;
-    required string state = 2;
+    uint64 timestamp = 1;
+    string state = 2;
 
-    required string executor_hostname = 4;
-    optional string reason = 5;
-    optional int32 task_failures = 6;
+    string executor_hostname = 4;
+    string reason = 5;
+    int32 task_failures = 6;
 }
 
 message TaskEvent {
-    required int64 start_time = 1;
-    required int64 completion_time = 2;
-    required string task_id = 3;
-    required string stage_id = 4;
-    required string attempt_id = 5;
+    int64 start_time = 1;
+    int64 completion_time = 2;
+    string task_id = 3;
+    string stage_id = 4;
+    string attempt_id = 5;
 
-    required string executor_hostname = 7;
+    string executor_hostname = 7;
 
-    optional string status = 8;
-    optional string failure_reason = 9;
+    string status = 8;
+    string failure_reason = 9;
 
-    optional int64 executor_cpu_time = 10;
-    optional int64 executor_deserialize_cpu_time = 11;
+    int64 executor_cpu_time = 10;
+    int64 executor_deserialize_cpu_time = 11;
 
-    optional int64 executor_run_time = 12;
-    optional int64 jvm_gc_time = 13;
-    optional int64 executor_deserialize_time = 14;
-    optional int64 result_serialization_time = 15;
+    int64 executor_run_time = 12;
+    int64 jvm_gc_time = 13;
+    int64 executor_deserialize_time = 14;
+    int64 result_serialization_time = 15;
 
-    optional int64 result_size = 16;
-    optional int64 peak_execution_memory = 17;
+    int64 result_size = 16;
+    int64 peak_execution_memory = 17;
 
-    optional int64 disk_bytes_spilled = 18;
-    optional int64 memory_bytes_spilled = 19;
+    int64 disk_bytes_spilled = 18;
+    int64 memory_bytes_spilled = 19;
 
-    optional int64 shuffle_read_records = 20;
-    optional int64 shuffle_read_fetch_wait_time = 21;
-    optional int64 shuffle_read_local_bytes = 22;
-    optional int64 shuffle_read_remote_bytes = 23;
-    optional int64 shuffle_read_total_bytes = 24;
-    optional int64 shuffle_read_local_blocks_fetched = 25;
-    optional int64 shuffle_read_remote_blocks_fetched = 26;
-    optional int64 shuffle_read_total_blocks_fetched = 27;
+    int64 shuffle_read_records = 20;
+    int64 shuffle_read_fetch_wait_time = 21;
+    int64 shuffle_read_local_bytes = 22;
+    int64 shuffle_read_remote_bytes = 23;
+    int64 shuffle_read_total_bytes = 24;
+    int64 shuffle_read_local_blocks_fetched = 25;
+    int64 shuffle_read_remote_blocks_fetched = 26;
+    int64 shuffle_read_total_blocks_fetched = 27;
 
-    optional int64 shuffle_write_shuffle_records = 28;
-    optional int64 shuffle_write_shuffle_time = 29;
-    optional int64 shuffle_write_shuffle_bytes = 30;
+    int64 shuffle_write_shuffle_records = 28;
+    int64 shuffle_write_shuffle_time = 29;
+    int64 shuffle_write_shuffle_bytes = 30;
 
-    optional int64 input_records = 31;
-    optional int64 input_bytes = 32;
-    optional int64 output_records = 33;
-    optional int64 output_bytes = 34;
+    int64 input_records = 31;
+    int64 input_bytes = 32;
+    int64 output_records = 33;
+    int64 output_bytes = 34;
 
-    optional string type = 35;
-    optional string locality = 36;
-    optional int32 attempt_number = 37;
+    string type = 35;
+    string locality = 36;
+    int32 attempt_number = 37;
 
 }
 


### PR DESCRIPTION
As we do not rely anymore on protobuf from hadoop release
and shade it relocated to a garmadon sub package we can bump it to
proto 3