### PR TITLE
Add ProtoConcatenator class for Protobuf & JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <protobuf.version>3.6.1</protobuf.version>
         <kafka.version>0.10.2.1</kafka.version>
         <guava.version>20.0</guava.version>
+        <protobuf-dynamic.version>0.9.4</protobuf-dynamic.version>
 
         <!-- tests -->
         <junit.version>4.12</junit.version>

--- a/readers/common/pom.xml
+++ b/readers/common/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.github.os72</groupId>
             <artifactId>protobuf-dynamic</artifactId>
-            <version>0.9.4</version>
+            <version>${protobuf-dynamic.version}</version>
         </dependency>
     </dependencies>
 

--- a/readers/common/pom.xml
+++ b/readers/common/pom.xml
@@ -51,6 +51,13 @@
             <artifactId>garmadon-schema</artifactId>
             <version>${garmadon.version}</version>
         </dependency>
+
+        <!-- Protobuf -->
+        <dependency>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protobuf-dynamic</artifactId>
+            <version>0.9.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
@@ -1,0 +1,152 @@
+package com.criteo.hadoop.garmadon.protobuf;
+
+import com.github.os72.protobuf.dynamic.DynamicSchema;
+import com.github.os72.protobuf.dynamic.MessageDefinition;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class ProtoConcatenator {
+    private static Logger LOGGER = LoggerFactory.getLogger(ProtoConcatenator.class);
+
+    /**
+     * Concatenate Protobuf messages into a single Protobuf message.
+     * /!\ Doesn't handle embedded objects and repeated fields /!\
+     *
+     * @param messages  Messages to be concatenated
+     * @return          A single, one-level Protobuf objects holding fields and values from all input messages.
+     *                  Null if an error occurred (shouldn't happen).
+     */
+    public static Message concatToProtobuf(Collection<Message> messages) {
+        try {
+            DynamicMessage.Builder messageBuilder = concatInner(messages,
+                    (keys) -> {
+                        try {
+                            return buildMessageBuilder("GeneratedObject", keys);
+                        } catch (Descriptors.DescriptorValidationException e) {
+                            LOGGER.error("Couldn't build concatenated Protobuf", e);
+                            throw new IllegalArgumentException(e);
+                        }
+                    },
+                    (entry, builder) -> {
+                        String fieldName = entry.getKey().getName();
+                        Descriptors.Descriptor descriptorForType = builder.getDescriptorForType();
+                        Descriptors.FieldDescriptor dstFieldDescriptor = descriptorForType.findFieldByName(fieldName);
+
+                        if (dstFieldDescriptor == null) {
+                            throw new IllegalArgumentException("Tried to fill a non-existing field: " + fieldName);
+                        }
+
+                        if (dstFieldDescriptor.isRepeated()) {
+                            setRepeatedField(builder, dstFieldDescriptor, entry);
+                        } else {
+                            builder.setField(dstFieldDescriptor, entry.getValue());
+                        }
+                    });
+
+            return messageBuilder.build();
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.error("Could not flatten Protobuf event", e);
+            return null;
+        }
+    }
+
+    /**
+     * Concatenate Protobuf messages into a single String -> object map.
+     * /!\ Doesn't handle embedded objects and repeated fields /!\
+     *
+     * @param messages  Messages to be concatenated
+     * @return          A single, one-level String -> object map holding fields and values from all input messages.
+     *                  Null if an error occurred (shouldn't happen).
+     */
+    public static Map<String, Object> concatToMap(Collection<Message> messages) {
+        return concatInner(messages, (ignored) -> new HashMap<>(), (entry, eventMap) -> {
+            eventMap.put(entry.getKey().getName(), entry.getValue());
+        });
+    }
+
+    /**
+     * Build a dynamic message builder based on a list of fields. Fields will be numbered in the order they were
+     * provided, starting from 1
+     *
+     * @param msgName   Name of the output message
+     * @param fields    Fields to be added to the output message definition
+     * @return          A builder able to fill a message made of all input fields
+     * @throws Descriptors.DescriptorValidationException    In case of a bug (shouldn't happen)
+     */
+    public static DynamicMessage.Builder buildMessageBuilder(String msgName, Collection<Descriptors.FieldDescriptor> fields)
+            throws Descriptors.DescriptorValidationException {
+        MessageDefinition.Builder msgDef = MessageDefinition.newBuilder(msgName);
+
+        int currentIndex = 1;
+
+        for (Descriptors.FieldDescriptor fieldDescriptor: fields) {
+            String label;
+
+            if (fieldDescriptor.isRepeated()) {
+                label = "repeated";
+            }
+            else
+                label = (fieldDescriptor.isRequired()) ? "required" : "optional";
+
+            msgDef.addField(label,
+                    fieldDescriptor.getType().toString().toLowerCase(), fieldDescriptor.getName(), currentIndex++);
+        }
+
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+        schemaBuilder.addMessageDefinition(msgDef.build());
+
+        DynamicSchema schema = schemaBuilder.build();
+
+        return schema.newMessageBuilder(msgName);
+    }
+
+    /**
+     * Concatenate Protobuf messages and feeds them to parameterizable consumers
+     * /!\ Doesn't handle embedded objects and repeated fields /!\
+     *
+     * @param messages              Messages to be concatenated
+     * @param messageBuilder        Callback invoked with all input fields. Returns the object to be filled by
+     *                              contentsConsumer.
+     * @param contentsConsumer      Callback invoked for every output field + contents, along with the messageBuilder.
+     *                              Returns false if something wrong happened.
+     *
+     * @return                      Whether all operations completed successfully
+     */
+    private static <MessageType> MessageType concatInner(Collection<Message> messages,
+                   Function<Collection<Descriptors.FieldDescriptor>, MessageType> messageBuilder,
+                   BiConsumer<Map.Entry<Descriptors.FieldDescriptor, Object>, MessageType> contentsConsumer) {
+        Collection<Map.Entry<Descriptors.FieldDescriptor, Object>> allFields = new HashSet<>();
+
+        for (Message message : messages) {
+            allFields.addAll(message.getAllFields().entrySet());
+        }
+
+        Collection<Descriptors.FieldDescriptor> allKeys = new LinkedList<>();
+        for (Message message : messages) {
+            allKeys.addAll(message.getDescriptorForType().getFields());
+        }
+
+        MessageType msg = messageBuilder.apply(allKeys);
+        allFields.forEach(field -> contentsConsumer.accept(field, msg));
+
+        return msg;
+    }
+
+    private static void setRepeatedField(DynamicMessage.Builder builder, Descriptors.FieldDescriptor dstFieldDescriptor,
+                                         Map.Entry<Descriptors.FieldDescriptor, Object> entry) {
+        @SuppressWarnings("unchecked")
+        Collection<Object> values = (Collection<Object>) entry.getValue();
+
+        for (Object value : values) {
+            builder.addRepeatedField(dstFieldDescriptor, value);
+        }
+    }
+}

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
@@ -17,7 +17,7 @@ public class ProtoConcatenator {
 
     /**
      * Concatenate Protobuf messages into a single Protobuf message.
-     * /!\ Doesn't handle embedded objects and repeated fields /!\
+     * /!\ Doesn't handle embedded objects /!\
      *
      * @param messages  Messages to be concatenated
      * @return          A single, one-level Protobuf objects holding fields and values from all input messages.
@@ -60,7 +60,7 @@ public class ProtoConcatenator {
 
     /**
      * Concatenate Protobuf messages into a single String -> object map.
-     * /!\ Doesn't handle embedded objects and repeated fields /!\
+     * /!\ Doesn't handle embedded objects /!\
      *
      * @param messages  Messages to be concatenated
      * @return          A single, one-level String -> object map holding fields and values from all input messages.

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
@@ -13,7 +13,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 public class ProtoConcatenator {
-    private static Logger LOGGER = LoggerFactory.getLogger(ProtoConcatenator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProtoConcatenator.class);
 
     /**
      * Concatenate Protobuf messages into a single Protobuf message.
@@ -25,7 +25,7 @@ public class ProtoConcatenator {
      */
     public static Message concatToProtobuf(Collection<Message> messages) {
         try {
-            DynamicMessage.Builder messageBuilder = concatInner(messages,
+            final DynamicMessage.Builder messageBuilder = concatInner(messages,
                     (keys) -> {
                         try {
                             return buildMessageBuilder("GeneratedObject", keys);
@@ -83,7 +83,7 @@ public class ProtoConcatenator {
      */
     public static DynamicMessage.Builder buildMessageBuilder(String msgName, Collection<Descriptors.FieldDescriptor> fields)
             throws Descriptors.DescriptorValidationException {
-        MessageDefinition.Builder msgDef = MessageDefinition.newBuilder(msgName);
+        final MessageDefinition.Builder msgDef = MessageDefinition.newBuilder(msgName);
 
         int currentIndex = 1;
 
@@ -100,10 +100,10 @@ public class ProtoConcatenator {
                     fieldDescriptor.getType().toString().toLowerCase(), fieldDescriptor.getName(), currentIndex++);
         }
 
-        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+        final DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
         schemaBuilder.addMessageDefinition(msgDef.build());
 
-        DynamicSchema schema = schemaBuilder.build();
+        final DynamicSchema schema = schemaBuilder.build();
 
         return schema.newMessageBuilder(msgName);
     }
@@ -123,13 +123,13 @@ public class ProtoConcatenator {
     private static <MessageType> MessageType concatInner(Collection<Message> messages,
                    Function<Collection<Descriptors.FieldDescriptor>, MessageType> messageBuilder,
                    BiConsumer<Map.Entry<Descriptors.FieldDescriptor, Object>, MessageType> contentsConsumer) {
-        Collection<Map.Entry<Descriptors.FieldDescriptor, Object>> allFields = new HashSet<>();
+        final Collection<Map.Entry<Descriptors.FieldDescriptor, Object>> allFields = new HashSet<>();
 
         for (Message message : messages) {
             allFields.addAll(message.getAllFields().entrySet());
         }
 
-        Collection<Descriptors.FieldDescriptor> allKeys = new LinkedList<>();
+        final Collection<Descriptors.FieldDescriptor> allKeys = new ArrayList<>();
         for (Message message : messages) {
             allKeys.addAll(message.getDescriptorForType().getFields());
         }
@@ -143,7 +143,7 @@ public class ProtoConcatenator {
     private static void setRepeatedField(DynamicMessage.Builder builder, Descriptors.FieldDescriptor dstFieldDescriptor,
                                          Map.Entry<Descriptors.FieldDescriptor, Object> entry) {
         @SuppressWarnings("unchecked")
-        Collection<Object> values = (Collection<Object>) entry.getValue();
+        final Collection<Object> values = (Collection<Object>) entry.getValue();
 
         for (Object value : values) {
             builder.addRepeatedField(dstFieldDescriptor, value);

--- a/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
+++ b/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
@@ -1,0 +1,265 @@
+package com.criteo.hadoop.garmadon.protobuf;
+
+import com.github.os72.protobuf.dynamic.DynamicSchema;
+import com.github.os72.protobuf.dynamic.MessageDefinition;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class ProtoConcatenatorTest {
+    @Test
+    public void concatenateEmptyList() {
+        testAllOutTypesWith(Collections.emptyList(), new HashMap<>());
+    }
+
+    @Test
+    public void concatenateSingleMessage() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder inMsg = createBodyBuilder();
+        Descriptors.Descriptor inMsgDesc = inMsg.getDescriptorForType();
+
+        inMsg.setField(inMsgDesc.findFieldByName("bodyInt"), 1);
+        inMsg.setField(inMsgDesc.findFieldByName("bodyString"), "one");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put("bodyInt", 1);
+        expectedValues.put("bodyString", "one");
+        testAllOutTypesWith(Collections.singletonList(inMsg.build()), expectedValues);
+    }
+
+    @Test
+    public void concatenateDifferentMessages() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder headerMessageBuilder = createHeaderMessageBuilder();
+        Descriptors.Descriptor headerMsgDesc = headerMessageBuilder.getDescriptorForType();
+
+        headerMessageBuilder.setField(headerMsgDesc.findFieldByName("id"), 1)
+                .setField(headerMsgDesc.findFieldByName("name"), "one");
+
+        DynamicMessage.Builder bodyMessageBuilder = createBodyBuilder();
+        Descriptors.Descriptor bodyMsgDesc = bodyMessageBuilder.getDescriptorForType();
+
+        bodyMessageBuilder.setField(bodyMsgDesc.findFieldByName("bodyInt"), 2)
+                .setField(bodyMsgDesc.findFieldByName("bodyString"), "two");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put("id", 1);
+        expectedValues.put("name", "one");
+        expectedValues.put("bodyInt", 2);
+        expectedValues.put("bodyString", "two");
+        testAllOutTypesWith(Arrays.asList(headerMessageBuilder.build(), bodyMessageBuilder.build()), expectedValues);
+    }
+
+    @Test
+    public void concatenateMessageWithItself() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder headerMessageBuilder = createHeaderMessageBuilder();
+        Descriptors.Descriptor headerMsgDesc = headerMessageBuilder.getDescriptorForType();
+
+        headerMessageBuilder.setField(headerMsgDesc.findFieldByName("id"), 1)
+                .setField(headerMsgDesc.findFieldByName("name"), "one");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put("id", 1);
+        expectedValues.put("name", "one");
+        testAllOutTypesWith(Arrays.asList(headerMessageBuilder.build(), headerMessageBuilder.build()),
+                expectedValues);
+    }
+
+    @Test
+    public void concatenateMessageWithEmpty() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder headerMessageBuilder = createHeaderMessageBuilder();
+        Descriptors.Descriptor headerMsgDesc = headerMessageBuilder.getDescriptorForType();
+
+        headerMessageBuilder.setField(headerMsgDesc.findFieldByName("id"), 1)
+                .setField(headerMsgDesc.findFieldByName("name"), "one");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put( "id", 1);
+        expectedValues.put("name", "one");
+        testAllOutTypesWith(Arrays.asList(headerMessageBuilder.build(), createEmptyMessage()), expectedValues);
+    }
+
+    @Test
+    public void concatenateEmptyWithEmpty() throws Descriptors.DescriptorValidationException {
+        testAllOutTypesWith(Arrays.asList(createEmptyMessage(), createEmptyMessage()), new HashMap<>());
+    }
+
+    @Test
+    public void concatenateMessagesWithClashingNamesAndIds() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder headerMessageBuilder = createHeaderMessageBuilder();
+        Descriptors.Descriptor headerMsgDesc = headerMessageBuilder.getDescriptorForType();
+
+        headerMessageBuilder.setField(headerMsgDesc.findFieldByName("id"), 1)
+                .setField(headerMsgDesc.findFieldByName("name"), "one");
+
+        DynamicMessage.Builder bodyMessageBuilder = createOtherHeaderMessageBuilder();
+        Descriptors.Descriptor bodyMsgDesc = bodyMessageBuilder.getDescriptorForType();
+
+        bodyMessageBuilder.setField(bodyMsgDesc.findFieldByName("otherId"), 2)
+                .setField(bodyMsgDesc.findFieldByName("otherName"), "two");
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        expectedValues.put("id", 1);
+        expectedValues.put("name", "one");
+        expectedValues.put("otherId", 2);
+        expectedValues.put("otherName", "two");
+        testAllOutTypesWith(Arrays.asList(headerMessageBuilder.build(), bodyMessageBuilder.build()), expectedValues);
+    }
+
+    @Test
+    public void concatenateMessageWithAllTypesWithEmpty() throws Descriptors.DescriptorValidationException {
+        DynamicMessage allTypesMessage = createMessageWithAllProtoTypes();
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        for (int i = 0; i < ALL_PROTOBUF_TYPES.size(); i++) {
+            expectedValues.put(ALL_PROTOBUF_TYPES.get(i), ALL_PROTOBUF_DEFAULT_VALUES.get(i));
+        }
+        testAllOutTypesWith(Arrays.asList(allTypesMessage, createEmptyMessage()), expectedValues);
+    }
+
+    @Test
+    public void concatenateMessageWithRepeatedFieldWithEmpty() throws Descriptors.DescriptorValidationException {
+        DynamicMessage.Builder messageWithRepeatedFieldBuilder = createMessageWithRepeatedField();
+        Descriptors.Descriptor msgDesc = messageWithRepeatedFieldBuilder.getDescriptorForType();
+
+        Message msg = messageWithRepeatedFieldBuilder
+                .addRepeatedField(msgDesc.findFieldByName("repeated_field"), 1)
+                .addRepeatedField(msgDesc.findFieldByName("repeated_field"), 2)
+                .build();
+
+        Map<String, Object> expectedValues = new HashMap<>();
+        ArrayList<Object> ints = new ArrayList<>(Arrays.asList(1, 2));
+        expectedValues.put("repeated_field", ints);
+
+        testAllOutTypesWith(Arrays.asList(msg, createEmptyMessage()), expectedValues);
+    }
+
+    /**
+     * Test input with all ProtoConcatenator methods/flavors
+     *
+     * @param inputMessages     Input Protobuf messages
+     * @param expectedValues    Strictly-expected values (must be equal in size and values to the output)
+     */
+    private void testAllOutTypesWith(Collection<Message> inputMessages, Map<String, Object> expectedValues) {
+        Message outProtoMessage = ProtoConcatenator.concatToProtobuf(inputMessages);
+
+        Assert.assertNotNull(outProtoMessage);
+        Assert.assertEquals(expectedValues.size(), outProtoMessage.getAllFields().size());
+        for (Map.Entry<String, Object> v: expectedValues.entrySet()) {
+            Assert.assertEquals(v.getValue(), getProtoFieldValueByName(outProtoMessage, v.getKey()));
+        }
+
+        Map<String, Object> outMap = ProtoConcatenator.concatToMap(inputMessages);
+
+        Assert.assertNotNull(outMap);
+        Assert.assertEquals(expectedValues.size(), outMap.size());
+        for (Map.Entry<String, Object> v: expectedValues.entrySet()) {
+            Assert.assertEquals(v.getValue(), outMap.get(v.getKey()));
+        }
+    }
+
+    private static Object getProtoFieldValueByName(Message message, String fieldName) {
+        return message.getField(message.getDescriptorForType().findFieldByName(fieldName));
+    }
+
+    private static final List<Object> ALL_PROTOBUF_DEFAULT_VALUES = Arrays.asList(0d, 0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0,
+            0L, true, "", ByteString.EMPTY);
+    private static final List<String> ALL_PROTOBUF_TYPES = Arrays.asList("double", "float", "int32", "int64", "uint32",
+            "uint64", "sint32", "sint64", "fixed32", "fixed64", "sfixed32", "sfixed64", "bool", "string", "bytes");
+
+    private static DynamicMessage createEmptyMessage() throws Descriptors.DescriptorValidationException {
+        String messageName = "Empty";
+        DynamicSchema.Builder builder = DynamicSchema.newBuilder();
+
+        builder.addMessageDefinition(MessageDefinition.newBuilder(messageName).build());
+
+        return builder.build().newMessageBuilder(messageName).build();
+    }
+
+    // Create a header with two fields: id and name
+    private static DynamicMessage.Builder createHeaderMessageBuilder() throws Descriptors.DescriptorValidationException {
+        String messageName = "Header";
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+
+        MessageDefinition msgDef = MessageDefinition.newBuilder(messageName)
+                .addField("required", "int32", "id", 1)
+                .addField("optional", "string", "name", 2)
+                .build();
+
+        schemaBuilder.addMessageDefinition(msgDef);
+        DynamicSchema schema = schemaBuilder.build();
+
+        return schema.newMessageBuilder(messageName);
+    }
+
+    // Create a message with all Protobuf types
+    private static DynamicMessage createMessageWithAllProtoTypes() throws Descriptors.DescriptorValidationException {
+        String messageName = "AllTypes";
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+        MessageDefinition.Builder msgBuilder = MessageDefinition.newBuilder(messageName);
+
+        int currentIndex = 1;
+        for (String typeName: ALL_PROTOBUF_TYPES) {
+            msgBuilder.addField("required", typeName, typeName, currentIndex++);
+        }
+
+        schemaBuilder.addMessageDefinition(msgBuilder.build());
+        DynamicSchema schema = schemaBuilder.build();
+        DynamicMessage.Builder builder = schema.newMessageBuilder(messageName);
+
+        Descriptors.Descriptor msgDesc = builder.getDescriptorForType();
+        for (int i = 0; i < ALL_PROTOBUF_DEFAULT_VALUES.size(); ++i) {
+            builder.setField(msgDesc.findFieldByNumber(i + 1), ALL_PROTOBUF_DEFAULT_VALUES.get(i));
+        }
+
+        return builder.build();
+    }
+
+    // Create a header with identical indexes & types as Header, but different names
+    private static DynamicMessage.Builder createOtherHeaderMessageBuilder() throws Descriptors.DescriptorValidationException {
+        String messageName = "OtherHeader";
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+
+        MessageDefinition msgDef = MessageDefinition.newBuilder(messageName)
+                .addField("required", "int32", "otherId", 1)
+                .addField("optional", "string", "otherName", 2)
+                .build();
+
+        schemaBuilder.addMessageDefinition(msgDef);
+        DynamicSchema schema = schemaBuilder.build();
+
+        return schema.newMessageBuilder(messageName);
+    }
+
+    // Create a body with indexes and field names different from Header & OtherHeader
+    private static DynamicMessage.Builder createBodyBuilder() throws Descriptors.DescriptorValidationException {
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+
+        MessageDefinition msgDef = MessageDefinition.newBuilder("Body")
+                .addField("required", "int32", "bodyInt", 3)
+                .addField("optional", "string", "bodyString", 4)
+                .build();
+
+        schemaBuilder.addMessageDefinition(msgDef);
+        DynamicSchema schema = schemaBuilder.build();
+
+        return schema.newMessageBuilder("Body");
+    }
+
+    private static DynamicMessage.Builder createMessageWithRepeatedField()
+            throws Descriptors.DescriptorValidationException {
+        DynamicSchema.Builder schemaBuilder = DynamicSchema.newBuilder();
+
+        MessageDefinition msgDef = MessageDefinition.newBuilder("Repeated")
+                .addField("repeated", "int32", "repeated_field", 1)
+                .build();
+
+        schemaBuilder.addMessageDefinition(msgDef);
+        DynamicSchema schema = schemaBuilder.build();
+
+        return schema.newMessageBuilder("Repeated");
+    }
+}

--- a/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
+++ b/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
@@ -64,8 +64,10 @@ public class ProtoConcatenatorTest {
         Map<String, Object> expectedValues = new HashMap<>();
         expectedValues.put("id", 1);
         expectedValues.put("name", "one");
-        testAllOutTypesWith(Arrays.asList(headerMessageBuilder.build(), headerMessageBuilder.build()),
-                expectedValues);
+
+        // As of proto3, two fields cannot have the same name (even if they have a different id)
+        Assert.assertNull(ProtoConcatenator.concatToProtobuf(
+                Arrays.asList(headerMessageBuilder.build(), headerMessageBuilder.build())));
     }
 
     @Test


### PR DESCRIPTION
Allows reading a complex message from Garmadon and outputting it as a single-level object in Protobuf or JSON