### PR TITLE
Get canonical hostname to ensure having same hostname format

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/Utils.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/Utils.java
@@ -14,7 +14,7 @@ public class Utils {
     public static String getHostname() {
         String hostname = "";
         try {
-            hostname = InetAddress.getLocalHost().getHostName();
+            hostname = InetAddress.getLocalHost().getCanonicalHostName();
         } catch (UnknownHostException ignored) {
         }
         return hostname;


### PR DESCRIPTION
Hostname from containers based on NM env variable is in canonical format
the one from standalone JVM is not leading to different format