### PR TITLE
Add process network statistics

### DIFF
--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/JVMStatistics.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/JVMStatistics.java
@@ -129,6 +129,7 @@ public class JVMStatistics {
         conf.setInterval(Duration.ofSeconds(1));
         conf.setLogJVMStats(JVMStatistics::log);
         conf.setLogGcStats(JVMStatistics::log);
+        conf.setLogMachineStats(JVMStatistics::log);
         JVMStatistics stats = new JVMStatistics(conf);
         stats.start();
         Thread t = new Thread(() -> {

--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/HotSpotMXBeanStatistics.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/HotSpotMXBeanStatistics.java
@@ -29,6 +29,7 @@ public class HotSpotMXBeanStatistics extends MXBeanStatistics {
     public void register(StatisticCollector collector) {
         super.register(collector);
         addProcessStatistics(collector);
+        addNetworkStatistics(collector);
         addSafepointStatistics(collector);
         addSynchronizationStatistics(collector);
         addFileDescriptorStatistics(collector);
@@ -126,6 +127,14 @@ public class HotSpotMXBeanStatistics extends MXBeanStatistics {
             collector.register(new ProcessStatistics());
         } catch (Throwable ex) {
             collector.delayRegister(ProcessStatistics::new);
+        }
+    }
+
+    protected void addNetworkStatistics(StatisticCollector collector) {
+        try {
+            collector.register(new NetworkStatistics());
+        } catch (Throwable ex) {
+            collector.delayRegister(NetworkStatistics::new);
         }
     }
 

--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/MachineNetworkStatistics.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/MachineNetworkStatistics.java
@@ -1,0 +1,88 @@
+package com.criteo.hadoop.garmadon.jvm.statistics;
+
+import com.criteo.hadoop.garmadon.jvm.AbstractStatistic;
+import com.criteo.hadoop.garmadon.jvm.StatisticsSink;
+import oshi.SystemInfo;
+import oshi.hardware.NetworkIF;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MachineNetworkStatistics extends AbstractStatistic {
+    private static final String NETWORK_HEADER = "network";
+    private static final String NETWORK_RECV_SUFFIX = "_rx";
+    private static final String NETWORK_SENT_SUFFIX = "_tx";
+    private static final String NETWORK_PKT_RECV_SUFFIX = "_pktrx";
+    private static final String NETWORK_PKT_SENT_SUFFIX = "_pkttx";
+    private static final String NETWORK_ERRORS_IN_SUFFIX = "_errin";
+    private static final String NETWORK_ERRORS_OUT_SUFFIX = "_errout";
+
+    private final List<NicInfo> nics = new ArrayList<>();
+
+    MachineNetworkStatistics() {
+        super(NETWORK_HEADER);
+        for (NetworkIF nic : new SystemInfo().getHardware().getNetworkIFs()) {
+            if (nic.getBytesSent() == 0 && nic.getBytesRecv() == 0) {
+                // nothing happens on this nic since boot
+                continue;
+            }
+            nics.add(new NicInfo(nic));
+        }
+    }
+
+    @Override
+    protected void innerCollect(StatisticsSink sink) throws Throwable {
+        for (NicInfo nic : nics) {
+            nic.dumpStats(sink);
+        }
+    }
+
+
+    private static class NicInfo {
+        private final NetworkIF nic;
+        private final String recvProp;
+        private final String sentProp;
+        private final String pktRecvProp;
+        private final String pktSentProp;
+        private final String errInProp;
+        private final String errOutProp;
+        private long previousRx;
+        private long previousTx;
+        private long previousPktRx;
+        private long previousPktTx;
+        private long previousErrIn;
+        private long previousErrOut;
+
+        public NicInfo(NetworkIF nic) {
+            this.nic = nic;
+            this.recvProp = nic.getName() + NETWORK_RECV_SUFFIX;
+            this.sentProp = nic.getName() + NETWORK_SENT_SUFFIX;
+            this.pktRecvProp = nic.getName() + NETWORK_PKT_RECV_SUFFIX;
+            this.pktSentProp = nic.getName() + NETWORK_PKT_SENT_SUFFIX;
+            this.errInProp = nic.getName() + NETWORK_ERRORS_IN_SUFFIX;
+            this.errOutProp = nic.getName() + NETWORK_ERRORS_OUT_SUFFIX;
+            this.previousRx = nic.getBytesRecv();
+            this.previousTx = nic.getBytesSent();
+            this.previousPktRx = nic.getPacketsRecv();
+            this.previousPktTx = nic.getPacketsSent();
+            this.previousErrIn = nic.getInErrors();
+            this.previousErrOut = nic.getOutErrors();
+        }
+
+        public void dumpStats(StatisticsSink sink) {
+            nic.updateNetworkStats();
+            sink.add(recvProp, nic.getBytesRecv() - previousRx);
+            previousRx = nic.getBytesRecv();
+            sink.add(sentProp, nic.getBytesSent() - previousTx);
+            previousTx = nic.getBytesSent();
+            sink.add(pktRecvProp, nic.getPacketsRecv() - previousPktRx);
+            previousPktRx = nic.getPacketsRecv();
+            sink.add(pktSentProp, nic.getPacketsSent() - previousPktTx);
+            previousPktTx = nic.getPacketsSent();
+            sink.add(errInProp, nic.getInErrors() - previousErrIn);
+            previousErrIn = nic.getInErrors();
+            sink.add(errOutProp, nic.getOutErrors() - previousErrOut);
+            previousErrOut = nic.getOutErrors();
+        }
+    }
+}

--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/MachineStatistics.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/MachineStatistics.java
@@ -6,7 +6,7 @@ public class MachineStatistics {
     public void register(StatisticCollector collector) {
         collector.register(new MachineCpuStatistics());
         collector.register(new MemoryStatistics());
-        collector.register(new NetworkStatistics());
+        collector.register(new MachineNetworkStatistics());
         collector.register(new DiskStatistics());
     }
 }

--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/NetworkStatistics.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/statistics/NetworkStatistics.java
@@ -2,86 +2,216 @@ package com.criteo.hadoop.garmadon.jvm.statistics;
 
 import com.criteo.hadoop.garmadon.jvm.AbstractStatistic;
 import com.criteo.hadoop.garmadon.jvm.StatisticsSink;
-import oshi.SystemInfo;
-import oshi.hardware.NetworkIF;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class NetworkStatistics extends AbstractStatistic {
     private static final String NETWORK_HEADER = "network";
-    private static final String NETWORK_RECV_SUFFIX = "_rx";
-    private static final String NETWORK_SENT_SUFFIX = "_tx";
-    private static final String NETWORK_PKT_RECV_SUFFIX = "_pktrx";
-    private static final String NETWORK_PKT_SENT_SUFFIX = "_pkttx";
-    private static final String NETWORK_ERRORS_IN_SUFFIX = "_errin";
-    private static final String NETWORK_ERRORS_OUT_SUFFIX = "_errout";
+    private static final String NETWORK_PROCESS_RECV = "processrx";
+    private static final String NETWORK_PROCESS_SENT = "processtx";
+    private static final Pattern SS_SOCKET_LINE_1 = Pattern.compile("ESTAB\\s+\\d+\\s+\\d+\\s+(\\d+\\.\\d+\\.\\d+.\\d+:\\d+)\\s+(\\d+\\.\\d+\\.\\d+.\\d+:\\d+)\\s+users:\\(\\(.*,pid=(\\d+),.*\\)\\)");
+    private static final Pattern SS_SOCKET_LINE_RECEIVED = Pattern.compile("bytes_received:(\\d+)");
+    private static final Pattern SS_SOCKET_LINE_ACKED = Pattern.compile("bytes_acked:(\\d+)");
+    private static final File PROC_FILE = new File("/proc");
 
-    private final List<NicInfo> nics = new ArrayList<>();
+    private final int currentPid;
+    private final Map<String, SocketStats> socketStats = new HashMap<>();
 
-    NetworkStatistics() {
+    public NetworkStatistics() {
         super(NETWORK_HEADER);
-        for (NetworkIF nic : new SystemInfo().getHardware().getNetworkIFs()) {
-            if (nic.getBytesSent() == 0 && nic.getBytesRecv() == 0) {
-                // nothing happens on this nic since boot
-                continue;
-            }
-            nics.add(new NicInfo(nic));
-        }
+        this.currentPid = extractCurrentPid();
     }
 
     @Override
     protected void innerCollect(StatisticsSink sink) throws Throwable {
-        for (NicInfo nic : nics) {
-            nic.dumpStats(sink);
+        ProcessBuilder builder = new ProcessBuilder("/usr/sbin/ss", "-tinp");
+        try {
+            Process process = builder.start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                return;
+            }
+            Map<Integer, ProcessNetworkStats> processNetworkStatsMap = getProcessNetworkStats(process);
+            Map<Integer, ProcessInfo> processes = listProcess(processNetworkStatsMap);
+            resolveProcessTree(processes);
+            collectNetworkStats(processes, sink);
+        } catch (IOException ignored) {
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
-    private static class NicInfo {
-        private final NetworkIF nic;
-        private final String recvProp;
-        private final String sentProp;
-        private final String pktRecvProp;
-        private final String pktSentProp;
-        private final String errInProp;
-        private final String errOutProp;
-        private long previousRx;
-        private long previousTx;
-        private long previousPktRx;
-        private long previousPktTx;
-        private long previousErrIn;
-        private long previousErrOut;
+    private void collectNetworkStats(Map<Integer, ProcessInfo> processes, StatisticsSink sink) {
+        ProcessInfo processInfo = processes.get(currentPid);
+        updateSocketStats(processInfo);
+        for (ProcessInfo child : processInfo.children) {
+            updateSocketStats(child);
+        }
+        long recvBytes = 0;
+        long sentBytes = 0;
+        for (SocketStats ss : socketStats.values()) {
+            recvBytes += ss.bytesReceived;
+            sentBytes += ss.bytesAcked;
+        }
+        sink.add(NETWORK_PROCESS_RECV, recvBytes);
+        sink.add(NETWORK_PROCESS_SENT, sentBytes);
+    }
 
-        public NicInfo(NetworkIF nic) {
-            this.nic = nic;
-            this.recvProp = nic.getName() + NETWORK_RECV_SUFFIX;
-            this.sentProp = nic.getName() + NETWORK_SENT_SUFFIX;
-            this.pktRecvProp = nic.getName() + NETWORK_PKT_RECV_SUFFIX;
-            this.pktSentProp = nic.getName() + NETWORK_PKT_SENT_SUFFIX;
-            this.errInProp = nic.getName() + NETWORK_ERRORS_IN_SUFFIX;
-            this.errOutProp = nic.getName() + NETWORK_ERRORS_OUT_SUFFIX;
-            this.previousRx = nic.getBytesRecv();
-            this.previousTx = nic.getBytesSent();
-            this.previousPktRx = nic.getPacketsRecv();
-            this.previousPktTx = nic.getPacketsSent();
-            this.previousErrIn = nic.getInErrors();
-            this.previousErrOut = nic.getOutErrors();
+    private void updateSocketStats(ProcessInfo processInfo) {
+        if (processInfo.netStats != null) {
+            socketStats.putAll(processInfo.netStats.socketStats);
+        }
+    }
+
+    private Map<Integer, ProcessNetworkStats> getProcessNetworkStats(Process process) throws IOException {
+        Map<Integer, ProcessNetworkStats> processNetworkStatsMap = new HashMap<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            int pid = -1;
+            String localSocket = null;
+            String remoteSocket = null;
+            while ((line = reader.readLine()) != null) {
+                if (pid == -1) {
+                    Matcher line1 = SS_SOCKET_LINE_1.matcher(line);
+                    if (line1.find()) {
+                        localSocket = line1.group(1);
+                        remoteSocket = line1.group(2);
+                        pid = Integer.valueOf(line1.group(3));
+                    }
+                } else {
+                    long bytesAcked = 0;
+                    Matcher acked = SS_SOCKET_LINE_ACKED.matcher(line);
+                    if (acked.find()) {
+                        bytesAcked = Long.valueOf(acked.group(1));
+                    }
+                    long bytesReceived = 0;
+                    Matcher received = SS_SOCKET_LINE_RECEIVED.matcher(line);
+                    if (received.find()) {
+                        bytesReceived = Long.valueOf(received.group(1));
+                    }
+                    ProcessNetworkStats processNetworkStats = processNetworkStatsMap.computeIfAbsent(pid, ProcessNetworkStats::new);
+                    processNetworkStats.put(localSocket + "#" + remoteSocket, bytesAcked, bytesReceived);
+                    pid = -1;
+                }
+            }
+        }
+        return processNetworkStatsMap;
+    }
+
+    private static boolean isAllDigits(File dir, String name) {
+        for (int i = 0; i < name.length(); i++) {
+            if (!Character.isDigit(name.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Map<Integer, ProcessInfo> listProcess(Map<Integer, ProcessNetworkStats> processNetworkStatsMap) {
+        String[] pids = PROC_FILE.list(NetworkStatistics::isAllDigits);
+        if (pids == null) {
+            return Collections.emptyMap();
+        }
+        Map<Integer, ProcessInfo> processes = new HashMap<>();
+        for (String pid : pids) {
+            try {
+                try (RandomAccessFile raf = new RandomAccessFile("/proc/" + pid + "/stat", "r")) {
+                    String[] stat = LinuxHelper.getFileLineSplit(raf);
+                    if (stat.length < 24) {
+                        continue;
+                    }
+                    int intPid = Integer.valueOf(pid);
+                    int parentPid = Integer.valueOf(stat[3]);
+                    ProcessInfo pi = processes.computeIfAbsent(intPid, intpid -> new ProcessInfo(intPid, parentPid));
+                    ProcessNetworkStats processNetworkStats = processNetworkStatsMap.get(intPid);
+                    if (processNetworkStats != null) {
+                        pi.netStats = processNetworkStats;
+                    }
+                }
+            } catch (IOException ignored) {
+            }
+        }
+        return processes;
+    }
+
+    private void resolveProcessTree(Map<Integer, ProcessInfo> processes) {
+        for (ProcessInfo pi : processes.values()) {
+            ProcessInfo parent = processes.get(pi.parentPid);
+            if (parent != null) {
+                parent.addChild(pi);
+            }
+        }
+    }
+
+    private int extractCurrentPid() {
+        String vmName = ManagementFactory.getRuntimeMXBean().getName();
+        int idx = vmName.indexOf('@');
+        if (idx == -1) {
+            return -1;
+        }
+        return Integer.valueOf(vmName.substring(0, idx));
+    }
+
+    private static class ProcessInfo {
+        private final int pid;
+        private final int parentPid;
+        private List<ProcessInfo> children = Collections.emptyList();
+        private ProcessNetworkStats netStats;
+
+        public ProcessInfo(int pid, int parentPid) {
+            this.pid = pid;
+            this.parentPid = parentPid;
         }
 
-        public void dumpStats(StatisticsSink sink) {
-            nic.updateNetworkStats();
-            sink.add(recvProp, nic.getBytesRecv() - previousRx);
-            previousRx = nic.getBytesRecv();
-            sink.add(sentProp, nic.getBytesSent() - previousTx);
-            previousTx = nic.getBytesSent();
-            sink.add(pktRecvProp, nic.getPacketsRecv() - previousPktRx);
-            previousPktRx = nic.getPacketsRecv();
-            sink.add(pktSentProp, nic.getPacketsSent() - previousPktTx);
-            previousPktTx = nic.getPacketsSent();
-            sink.add(errInProp, nic.getInErrors() - previousErrIn);
-            previousErrIn = nic.getInErrors();
-            sink.add(errOutProp, nic.getOutErrors() - previousErrOut);
-            previousErrOut = nic.getOutErrors();
+        public void addChild(ProcessInfo child) {
+            if (children == Collections.<ProcessInfo>emptyList()) {
+                children = new ArrayList<>();
+            }
+            children.add(child);
+        }
+    }
+
+    private static class ProcessNetworkStats {
+        private final int pid;
+        private Map<String, SocketStats> socketStats = new HashMap<>();
+
+        public ProcessNetworkStats(int pid) {
+            this.pid = pid;
+        }
+
+        public void put(String key, long bytesAcked, long bytesReceived) {
+            SocketStats socketStats = this.socketStats.computeIfAbsent(key, k -> new SocketStats(k, bytesAcked, bytesReceived));
+            socketStats.update(bytesAcked, bytesReceived);
+        }
+    }
+
+    private static class SocketStats {
+        private final String key;
+        private long bytesAcked;
+        private long bytesReceived;
+
+        public SocketStats(String key, long bytesAcked, long bytesReceived) {
+            this.key = key;
+            this.bytesAcked = bytesAcked;
+            this.bytesReceived = bytesReceived;
+        }
+
+        public void update(long bytesAcked, long bytesReceived) {
+            this.bytesAcked = bytesAcked;
+            this.bytesReceived = bytesReceived;
         }
     }
 }

--- a/readers/elasticsearch/src/main/elasticsearch/es/template.json
+++ b/readers/elasticsearch/src/main/elasticsearch/es/template.json
@@ -557,6 +557,10 @@
           "type": "long",
           "index": false
         },
+        "processrx": {
+          "type": "long",
+          "index": false
+        },
         "safepoints_count": {
           "type": "integer",
           "index": false
@@ -753,6 +757,10 @@
           "index": false
         },
         "errout": {
+          "type": "long",
+          "index": false
+        },
+        "processtx": {
           "type": "long",
           "index": false
         },


### PR DESCRIPTION
Add processrx & processtx properties that show bytes received & sent by the
sockets associated to this process or forked one.
Based on command "ss -tinp" which we parse and resolve with the list of
processes to handle forked process and sum them up to the initial JVM process

Notes:
- Handle only IPv4
- based on the refresh rate, it can miss connections that may be short lived
between 2 collections. So this is only an estimation, not accurate numbers.