### PR TITLE
Add Presto module based on StandaloneModule

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -113,6 +113,12 @@
             <version>${hadoop.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${presto.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/PrestoModule.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/PrestoModule.java
@@ -7,35 +7,18 @@ import com.criteo.hadoop.garmadon.agent.tracers.jvm.JVMStatisticsTracer;
 import com.criteo.hadoop.garmadon.agent.tracers.presto.PluginClassLoaderTracer;
 
 import java.lang.instrument.Instrumentation;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 public class PrestoModule implements GarmadonAgentModule {
 
     @Override
     public void setup(Instrumentation instrumentation, AsyncEventProcessor eventProcessor) {
-        ExecutorService executorService = Executors.newFixedThreadPool(5);
         // JVM/GC metrics/events
-        executorService.submit(() -> JVMStatisticsTracer.setup(
-                (timestamp, event) -> eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event)));
+        JVMStatisticsTracer.setup((timestamp, event) ->
+                eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event));
 
         // Byte code instrumentation
-        executorService.submit(() -> PluginClassLoaderTracer.setup(instrumentation));
-        executorService.submit(() -> FileSystemTracer.setup(instrumentation,
-                (timestamp, event) -> eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event)));
-
-        executorService.shutdown();
-        // We wait 3 sec executor to instrument classes
-        // If all classes are still not instrumented after that time we let the JVM continue startup
-        // in order to not block the container for too long on agent initialization
-        // Currently we are seeing avg duration of 160 s on MapRed and 6500 s on SPARK
-        // so we consider 3s as a reasonable duration
-        // Downside: we can have some classes not instrumenting loaded by the JVM so missing
-        // some metrics on a container
-        try {
-            executorService.awaitTermination(3000, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException ignored) {
-        }
+        PluginClassLoaderTracer.setup(instrumentation);
+        FileSystemTracer.setup(instrumentation, (timestamp, event) ->
+                eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event));
     }
 }

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/PrestoModule.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/PrestoModule.java
@@ -1,0 +1,41 @@
+package com.criteo.hadoop.garmadon.agent.modules;
+
+import com.criteo.hadoop.garmadon.agent.AsyncEventProcessor;
+import com.criteo.hadoop.garmadon.agent.headers.StandaloneHeader;
+import com.criteo.hadoop.garmadon.agent.tracers.hadoop.hdfs.FileSystemTracer;
+import com.criteo.hadoop.garmadon.agent.tracers.jvm.JVMStatisticsTracer;
+import com.criteo.hadoop.garmadon.agent.tracers.presto.PluginClassLoaderTracer;
+
+import java.lang.instrument.Instrumentation;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class PrestoModule implements GarmadonAgentModule {
+
+    @Override
+    public void setup(Instrumentation instrumentation, AsyncEventProcessor eventProcessor) {
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        // JVM/GC metrics/events
+        executorService.submit(() -> JVMStatisticsTracer.setup(
+                (timestamp, event) -> eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event)));
+
+        // Byte code instrumentation
+        executorService.submit(() -> PluginClassLoaderTracer.setup(instrumentation));
+        executorService.submit(() -> FileSystemTracer.setup(instrumentation,
+                (timestamp, event) -> eventProcessor.offer(timestamp, StandaloneHeader.getInstance().getHeader(), event)));
+
+        executorService.shutdown();
+        // We wait 3 sec executor to instrument classes
+        // If all classes are still not instrumented after that time we let the JVM continue startup
+        // in order to not block the container for too long on agent initialization
+        // Currently we are seeing avg duration of 160 s on MapRed and 6500 s on SPARK
+        // so we consider 3s as a reasonable duration
+        // Downside: we can have some classes not instrumenting loaded by the JVM so missing
+        // some metrics on a container
+        try {
+            executorService.awaitTermination(3000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ignored) {
+        }
+    }
+}

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/Tracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/Tracer.java
@@ -34,6 +34,7 @@ public abstract class Tracer {
                 "org.apache.flink.",
                 "org.apache.hadoop.",
                 "org.apache.spark.",
+                "com.facebook.presto.",
                 "com.criteo.",
         };
         String[] predefBlacklist = {

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/presto/PluginClassLoaderTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/presto/PluginClassLoaderTracer.java
@@ -1,0 +1,60 @@
+package com.criteo.hadoop.garmadon.agent.tracers.presto;
+
+import com.criteo.hadoop.garmadon.agent.tracers.ConstructorTracer;
+import com.google.common.collect.ImmutableList;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+
+public class PluginClassLoaderTracer {
+
+    protected PluginClassLoaderTracer() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static void setup(Instrumentation instrumentation) {
+        new PluginClassLoaderTracer.GarmadonLoadScope().installOn(instrumentation);
+    }
+
+    public static class GarmadonLoadScope extends ConstructorTracer {
+
+        @Override
+        protected ElementMatcher<? super TypeDescription> typeMatcher() {
+            return named("com.facebook.presto.server.PluginClassLoader");
+        }
+
+        @Override
+        protected ElementMatcher<? super MethodDescription> constructorMatcher() {
+            return takesArguments(4);
+        }
+
+        @Override
+        protected Implementation newImplementation() {
+            return Advice.to(PluginClassLoaderTracer.GarmadonLoadScope.class);
+        }
+
+        @Advice.OnMethodExit
+        public static void addGarmadonAgentPackage(@Advice.This Object o) throws Exception {
+            Class pluginClassLoaderZz = o.getClass().getClassLoader().loadClass("com.facebook.presto.server.PluginClassLoader");
+            Field spiClassLoaderField = pluginClassLoaderZz.getDeclaredField("spiPackages");
+            spiClassLoaderField.setAccessible(true);
+
+            ImmutableList<String> spiPackages = (ImmutableList<String>) spiClassLoaderField.get(o);
+            List<String> tmpspiPackages = new ArrayList<>(spiPackages);
+            tmpspiPackages.add("com.criteo.hadoop.garmadon.agent.");
+
+            spiClassLoaderField.set(o, ImmutableList.copyOf(tmpspiPackages));
+        }
+    }
+}

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/presto/package-info.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/presto/package-info.java
@@ -1,0 +1,5 @@
+package com.criteo.hadoop.garmadon.agent.tracers.presto;
+
+/**
+ * Tracers for presto
+ */

--- a/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracerTest.java
+++ b/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracerTest.java
@@ -77,7 +77,6 @@ public class FileSystemTracerTest {
                         HdfsDataOutputStream.class,
                         ClientNamenodeProtocolTranslatorPB.class,
                         Class.forName("org.apache.hadoop.hdfs.BlockReaderLocal"),
-                        Class.forName(FileSystemTracer.AddBlockTracer.class.getName() + "$SingletonHolder"),
                         Class.forName(DFSOutputStream.class.getName() + "$Packet"),
                         Class.forName(DFSOutputStream.class.getName() + "$DataStreamer"),
                         Class.forName(DFSOutputStream.class.getName() + "$DataStreamer$1"),

--- a/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/presto/PluginClassLoaderTracerTest.java
+++ b/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/presto/PluginClassLoaderTracerTest.java
@@ -1,0 +1,98 @@
+package com.criteo.hadoop.garmadon.agent.tracers.presto;
+
+import com.criteo.hadoop.garmadon.agent.tracers.ConstructorTracer;
+import com.criteo.hadoop.garmadon.agent.tracers.Tracer;
+import com.criteo.hadoop.garmadon.agent.utils.AgentAttachmentRule;
+import com.criteo.hadoop.garmadon.agent.utils.ClassFileExtraction;
+import com.google.common.collect.ImmutableList;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.dynamic.loading.ByteArrayClassLoader;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+
+import java.io.IOException;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class PluginClassLoaderTracerTest {
+    private static ClassLoader classLoader;
+
+    @Rule
+    public MethodRule agentAttachmentRule = new AgentAttachmentRule();
+
+    @BeforeClass
+    public static void setUpClass() throws IOException, ClassNotFoundException {
+        classLoader = new ByteArrayClassLoader.ChildFirst(PluginClassLoaderTracerTest.class.getClassLoader(),
+                ClassFileExtraction.of(
+                        Tracer.class,
+                        ConstructorTracer.class,
+                        PluginClassLoaderTracer.class,
+                        Class.forName("com.facebook.presto.server.PluginClassLoader")
+                ),
+                ByteArrayClassLoader.PersistenceHandler.MANIFEST);
+    }
+
+    @Test
+    @AgentAttachmentRule.Enforce
+    public void RMAppTracer_should_not_failed_attaching_RMContextImpl_constructior_due_to_TriConsumer_visibility()
+            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+            InstantiationException, MalformedURLException, NoSuchFieldException {
+        assertThat(ByteBuddyAgent.install(), instanceOf(Instrumentation.class));
+
+
+        ClassFileTransformer classFileTransformer = new PluginClassLoaderTracer.GarmadonLoadScope().installOnByteBuddyAgent();
+
+        try {
+            Class<?> clazz = classLoader.loadClass("com.facebook.presto.server.PluginClassLoader");
+
+            Constructor<?> constructor = clazz.getDeclaredConstructor(List.class, ClassLoader.class, Iterable.class);
+            constructor.setAccessible(true);
+
+            List<URL> urls = new ArrayList();
+            urls.add(new URL("file:///test"));
+
+            ImmutableList<String> SPI_PACKAGES = ImmutableList.<String>builder()
+                    .add("com.facebook.presto.spi.")
+                    .add("com.fasterxml.jackson.annotation.")
+                    .add("io.airlift.slice.")
+                    .add("io.airlift.units.")
+                    .add("org.openjdk.jol.")
+                    .build();
+
+            Object pluginClassLoader = constructor.newInstance(urls,
+                    classLoader,
+                    SPI_PACKAGES);
+
+            Field field = clazz.getDeclaredField("spiPackages");
+            field.setAccessible(true);
+            List<String> spiPackages = (List) field.get(pluginClassLoader);
+
+            assertEquals(ImmutableList.<String>builder()
+                    .add("com.facebook.presto.spi.")
+                    .add("com.fasterxml.jackson.annotation.")
+                    .add("io.airlift.slice.")
+                    .add("io.airlift.units.")
+                    .add("org.openjdk.jol.")
+                    .add("com.criteo.hadoop.garmadon.agent.")
+                    .build(), spiPackages);
+
+
+        } finally {
+            ByteBuddyAgent.getInstrumentation().removeTransformer(classFileTransformer);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <protobuf-dynamic.version>0.9.4</protobuf-dynamic.version>
         <jackson.version>2.9.7</jackson.version>
         <commons-io.version>2.6</commons-io.version>
+        <presto.version>0.206</presto.version>
 
         <!-- tests -->
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Presto use specific classloader for plugin with no parent.
This leads to garmadon class not being available for presto plugins
and also all libraries used by a plugin to not be loaded by parent classloader
so not being available for garmadon agent.
Using reflections on FileSystemTracer and ensuring that garmadon agent classes
are loaded from the App classloader and not the plugin one permits to use
trace hdfs call