### PR TITLE
[HDFS exporter] Add Prometheus metrics & align behavior with specs

### DIFF
--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
@@ -270,6 +270,10 @@ public final class GarmadonReader {
         }
 
         public Builder intercept(GarmadonMessageFilter filter, GarmadonMessageHandler handler) {
+            if (this.listeners.containsKey(filter)) {
+                LOGGER.warn("Multiple handlers set for filter of type {}", filter.getClass().toString());
+            }
+
             this.listeners.put(filter, handler);
             return this;
         }

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
@@ -57,6 +57,7 @@ public class PrometheusHttpConsumerMetrics {
         } catch (MalformedObjectNameException e) {
             LOGGER.error("", e);
         }
+
         scheduler.scheduleAtFixedRate(() -> {
             exposeKafkaMetrics();
         }, 0, 30, TimeUnit.SECONDS);

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
@@ -315,7 +315,7 @@ public class HdfsExporter {
     private static void printHelp() {
         System.out.println("Usage:");
         System.out.println("\tjava com.criteo.hadoop.garmadon.parquet.HdfsExporter " +
-                "kafka_connection_string kafka_group temp_dir final_dir");
+                "kafka_connection_string kafka_group temp_dir final_dir prometheus_port");
 
         System.out.println();
         System.out.println("Properties settable via -D:");

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/PrometheusMetrics.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/PrometheusMetrics.java
@@ -26,6 +26,9 @@ public final class PrometheusMetrics {
     public static final Gauge LATEST_COMMITTED_OFFSETS = buildGauge("latest_committed_offsets",
             "Latest committed offsets");
 
+    private PrometheusMetrics() {
+    }
+
     public static Gauge.Child buildGaugeChild(Gauge baseGauge, String eventName, int partition) {
         return baseGauge.labels(eventName, GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE,
                 String.valueOf(partition));
@@ -59,8 +62,5 @@ public final class PrometheusMetrics {
                 .name(name).help(help)
                 .labelNames("name", "hostname", "release", "partition")
                 .register();
-    }
-
-    private PrometheusMetrics() {
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/PrometheusMetrics.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/PrometheusMetrics.java
@@ -1,0 +1,66 @@
+package com.criteo.hadoop.garmadon.hdfs.monitoring;
+
+import com.criteo.hadoop.garmadon.reader.GarmadonReader;
+import com.criteo.hadoop.garmadon.reader.metrics.PrometheusHttpConsumerMetrics;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+
+public final class PrometheusMetrics {
+    // Output metrics
+    public static final Counter TMP_FILE_OPEN_FAILURES = buildCounter("tmp_file_open_failures",
+            "Failures to open temporary files", false);
+    public static final Counter FILES_COMMITTED = buildCounter("files_committed",
+            "Files moved to their final destination", false);
+    public static final Counter FILE_COMMIT_FAILURES = buildCounter("file_commit_failures",
+            "Failures when moving files to their final destination", false);
+    public static final Counter MESSAGES_WRITTEN = buildCounter("messages_written",
+            "Messages written to temporary files");
+    public static final Counter MESSAGES_WRITING_FAILURES = buildCounter("messages_writing_failures",
+            "Errors when writing messages to temporary files");
+    public static final Counter HEARTBEATS_SENT = buildCounter("heartbeats_sent",
+            "Number of heartbeats sent");
+
+    // Input metrics
+    public static final Gauge CURRENT_RUNNING_OFFSETS = buildGauge("current_running_offsets",
+            "Current offsets");
+    public static final Gauge LATEST_COMMITTED_OFFSETS = buildGauge("latest_committed_offsets",
+            "Latest committed offsets");
+
+    public static Gauge.Child buildGaugeChild(Gauge baseGauge, String eventName, int partition) {
+        return baseGauge.labels(eventName, GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE,
+                String.valueOf(partition));
+    }
+
+    public static Counter.Child buildCounterChild(Counter baseCounter, String eventName, int partition) {
+        return baseCounter.labels(eventName, GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE,
+                String.valueOf(partition));
+    }
+
+    public static Counter.Child buildCounterChild(Counter baseCounter, String eventName) {
+        return baseCounter.labels(eventName, GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE);
+    }
+
+    private static Counter buildCounter(String name, String help) {
+        return buildCounter(name, help, true);
+    }
+
+    private static Counter buildCounter(String name, String help, boolean withPartition) {
+        Counter.Builder builder = Counter.build()
+                .name(name).help(help);
+
+        if (withPartition) builder.labelNames("name", "hostname", "release", "partition");
+        else builder.labelNames("name", "hostname", "release");
+
+        return builder.register();
+    }
+
+    private static Gauge buildGauge(String name, String help) {
+        return Gauge.build()
+                .name(name).help(help)
+                .labelNames("name", "hostname", "release", "partition")
+                .register();
+    }
+
+    private PrometheusMetrics() {
+    }
+}

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/package-info.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/monitoring/package-info.java
@@ -1,0 +1,5 @@
+package com.criteo.hadoop.garmadon.hdfs.monitoring;
+
+/**
+ * Monitoring helpers for the HDFS exporter
+ */

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ExpiringConsumer.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ExpiringConsumer.java
@@ -18,7 +18,7 @@ public class ExpiringConsumer<MESSAGE_TYPE> implements CloseableBiConsumer<MESSA
     private final TemporalAmount expirationDelay;
     private long messagesReceived;
     private long messagesBeforeExpiring;
-    private Instant lastUpdate = Instant.now();
+    private Instant startDate = Instant.now();
 
     /**
      * @param writer                    The underlying messages writer. Must support receiving null events, which is a
@@ -40,7 +40,6 @@ public class ExpiringConsumer<MESSAGE_TYPE> implements CloseableBiConsumer<MESSA
      */
     @Override
     public void write(MESSAGE_TYPE message, Offset offset) throws IOException {
-        this.lastUpdate = Instant.now();
         ++this.messagesReceived;
 
         this.writer.write(message, offset);
@@ -52,11 +51,11 @@ public class ExpiringConsumer<MESSAGE_TYPE> implements CloseableBiConsumer<MESSA
     }
 
     /**
-     * @return  True if the writer is expired because of last update time being too far away in the past, or enough
+     * @return  True if the writer is expired because of creation date being too far away in the past, or enough
      *          messages being written
      */
     boolean isExpired() {
-        Instant expirationInstant = lastUpdate.plus(expirationDelay);
+        Instant expirationInstant = startDate.plus(expirationDelay);
 
         return messagesReceived >= messagesBeforeExpiring || Instant.now().isAfter(expirationInstant);
     }

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ExpiringConsumerTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ExpiringConsumerTest.java
@@ -50,9 +50,9 @@ public class ExpiringConsumerTest {
         Thread.sleep(1001);
         Assert.assertTrue(consumer.isExpired());
 
-        // Sending another message renews the expiration delay
+        // Sending another message doesn't renew the expiration delay
         consumer.write(12, DUMMY_OFFSET);
-        Assert.assertFalse(consumer.isExpired());
+        Assert.assertTrue(consumer.isExpired());
     }
 
     @Test

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
@@ -24,7 +24,7 @@ public class PartitionedWriterTest {
     public void writeToMultipleDaysAndPartitions() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
         final PartitionedWriter<String> partitionedWriter = new PartitionedWriter<>(writerBuilder,
-                new FixedOffsetComputer("ignored", 0));
+                new FixedOffsetComputer("ignored", 0), "ignored");
         final ExpiringConsumer<String> firstConsumerMock = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> secondConsumerMock = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> thirdConsumerMock = mock(ExpiringConsumer.class);
@@ -76,7 +76,7 @@ public class PartitionedWriterTest {
     public void writeOnExpired() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
         final PartitionedWriter<String> partitionedWriter = new PartitionedWriter<>(writerBuilder,
-                new FixedOffsetComputer("ignored", 0));
+                new FixedOffsetComputer("ignored", 0), "ignored");
         final ExpiringConsumer<String> firstDayFirstConsumerMock = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> firstDaySecondConsumerMock = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> secondDayFirstConsumerMock = mock(ExpiringConsumer.class);
@@ -126,7 +126,7 @@ public class PartitionedWriterTest {
     @Test
     public void expireNoWriter() {
         final PartitionedWriter partitionedWriter = new PartitionedWriter<String>(null,
-                new FixedOffsetComputer("ignored", 0));
+                new FixedOffsetComputer("ignored", 0), "ignored");
 
         // Should not crash
         partitionedWriter.expireConsumers();
@@ -136,7 +136,7 @@ public class PartitionedWriterTest {
     public void closingExceptionalConsumerDoesNotThrow() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
         final PartitionedWriter<String> partitionedWriter = new PartitionedWriter<>(writerBuilder,
-                new FixedOffsetComputer("ignored", 0));
+                new FixedOffsetComputer("ignored", 0), "ignored");
         final ExpiringConsumer<String> nonThrowingConsumer = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> throwingConsumer = mock(ExpiringConsumer.class);
         final Offset firstOffset = buildOffset(1, 101);
@@ -162,7 +162,7 @@ public class PartitionedWriterTest {
     public void skipMessagesBeforeLowestOffset() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
         final PartitionedWriter<String> writer = new PartitionedWriter<>(writerBuilder,
-                new FixedOffsetComputer("ignored", 42));
+                new FixedOffsetComputer("ignored", 42), "ignored");
 
         writer.write(Instant.EPOCH, buildOffset(1, 10), "Ignored");
         writer.write(Instant.EPOCH, buildOffset(1, 11), "Also ignored");
@@ -174,7 +174,7 @@ public class PartitionedWriterTest {
     public void dropPartition() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
         final OffsetComputer offsetComputer = mock(OffsetComputer.class);
-        final PartitionedWriter<String> writer = new PartitionedWriter<>(writerBuilder, offsetComputer);
+        final PartitionedWriter<String> writer = new PartitionedWriter<>(writerBuilder, offsetComputer, "ignored");
         final ExpiringConsumer<String> firstMockConsumer = mock(ExpiringConsumer.class);
         final ExpiringConsumer<String> secondMockConsumer = mock(ExpiringConsumer.class);
         final Instant instant = Instant.EPOCH;
@@ -199,7 +199,7 @@ public class PartitionedWriterTest {
     @Test
     public void dropUnknownPartition() throws IOException {
         final Function<LocalDateTime, ExpiringConsumer<String>> writerBuilder = mock(Function.class);
-        final PartitionedWriter<String> writer = new PartitionedWriter<>(writerBuilder, mock(OffsetComputer.class));
+        final PartitionedWriter<String> writer = new PartitionedWriter<>(writerBuilder, mock(OffsetComputer.class), "ignored");
 
         when(writerBuilder.apply(any(LocalDateTime.class))).thenReturn(mock(ExpiringConsumer.class));
 
@@ -215,7 +215,8 @@ public class PartitionedWriterTest {
         final long secondOffset = 30;
         final int partition = 42;
         final OffsetComputer offsetComputer = mock(OffsetComputer.class);
-        final PartitionedWriter<String> writer = new PartitionedWriter<>(mock(Function.class), offsetComputer);
+        final PartitionedWriter<String> writer = new PartitionedWriter<>(mock(Function.class), offsetComputer,
+                "ignored");
 
         when(offsetComputer.computeOffset(anyInt())).thenReturn(firstOffset).thenReturn(secondOffset);
 
@@ -235,7 +236,7 @@ public class PartitionedWriterTest {
         final Offset offset = new TopicPartitionOffset("topic", partition, 123);
         final ExpiringConsumer<String> consumer = mock(ExpiringConsumer.class);
         final PartitionedWriter<String> writer = new PartitionedWriter<>((ignored) -> consumer,
-                mock(OffsetComputer.class));
+                mock(OffsetComputer.class), "ignored");
 
         writer.heartbeat(partition, offset);
 
@@ -250,7 +251,7 @@ public class PartitionedWriterTest {
         final Offset offset = new TopicPartitionOffset("topic", partition, offsetValue);
         final ExpiringConsumer<String> consumer = mock(ExpiringConsumer.class);
         final PartitionedWriter<String> writer = new PartitionedWriter<>((ignored) -> consumer,
-                mock(OffsetComputer.class));
+                mock(OffsetComputer.class), "ignored");
 
         writer.write(Instant.EPOCH, offset, "Message");
         writer.heartbeat(partition, offset);

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
@@ -46,7 +46,7 @@ public class ProtoParquetWriterWithOffsetTest {
         final Message firstMessageMock = mock(Message.class);
         final Message secondMessageMock = mock(Message.class);
         final ProtoParquetWriterWithOffset consumer = new ProtoParquetWriterWithOffset<>(writerMock, tmpPath,
-                finalPath, fsMock, new FixedOffsetComputer(FINAL_FILE_NAME, 123), LocalDateTime.MIN);
+                finalPath, fsMock, new FixedOffsetComputer(FINAL_FILE_NAME, 123), LocalDateTime.MIN, "ignored");
 
         consumer.write(firstMessageMock, new TopicPartitionOffset(TOPIC, 1, 2));
         consumer.write(secondMessageMock, new TopicPartitionOffset(TOPIC, 1, 3));
@@ -72,7 +72,7 @@ public class ProtoParquetWriterWithOffsetTest {
     public void closeWithNoEvent() throws IOException {
         final ProtoParquetWriter<Message> writerMock = mock(ProtoParquetWriter.class);
         final ProtoParquetWriterWithOffset parquetWriter = new ProtoParquetWriterWithOffset<>(writerMock,
-                new Path("tmp"), new Path("final"), null, null, LocalDateTime.MIN);
+                new Path("tmp"), new Path("final"), null, null, LocalDateTime.MIN, "ignored");
 
         parquetWriter.close();
     }
@@ -83,7 +83,7 @@ public class ProtoParquetWriterWithOffsetTest {
         final FileSystem fsMock = mock(FileSystem.class);
         final OffsetComputer fileNamer = mock(OffsetComputer.class);
         final ProtoParquetWriterWithOffset parquetWriter = new ProtoParquetWriterWithOffset<>(writerMock,
-                new Path("tmp"), new Path("final"), fsMock, fileNamer, LocalDateTime.MIN);
+                new Path("tmp"), new Path("final"), fsMock, fileNamer, LocalDateTime.MIN, "ignored");
         boolean thrown = false;
 
         // We need to write one event, otherwise we will fail with a "no message" error
@@ -147,7 +147,7 @@ public class ProtoParquetWriterWithOffsetTest {
             long offset = 1;
 
             final ProtoParquetWriterWithOffset consumer = new ProtoParquetWriterWithOffset<>(writer, tmpPath, baseDir,
-                    localFs, new FixedOffsetComputer(FINAL_FILE_NAME, 123), UTC_EPOCH);
+                    localFs, new FixedOffsetComputer(FINAL_FILE_NAME, 123), UTC_EPOCH, "ignored");
 
             for (EventHeaderProtos.Header header : inputHeaders) {
                 consumer.write(header, new TopicPartitionOffset(TOPIC, 1, offset++));


### PR DESCRIPTION
* Writers expire after a given delay after the start (and not last update)
* Warn if two callbacks are registered for a same GarmadonFilter