### PR TITLE
Add back normalization on FS_EVENT removed when migrating to ProtoConcatenator concatToMap function

### DIFF
--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
@@ -98,7 +98,7 @@ public final class ElasticSearchReader {
 
     void writeToES(GarmadonMessage msg) {
         String msgType = GarmadonSerialization.getTypeName(msg.getType());
-        if ("JVMSTATS_EVENT".equals(msgType)) {
+        if (GarmadonSerialization.TypeMarker.JVMSTATS_EVENT == msg.getType()) {
             Map<String, Object> jsonMap = ProtoConcatenator.concatToMap(Arrays.asList(msg.getHeader()), true);
 
             HashMap<String, Map<String, Object>> eventMaps = new HashMap<>();

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
@@ -113,7 +113,7 @@ public final class ElasticSearchReader {
             eventMap.put("event_type", msgType);
 
             // Specific normalization for FS_EVENT
-            if ("FS_EVENT".equals(msgType)) {
+            if (GarmadonSerialization.TypeMarker.FS_EVENT == msg.getType()) {
                 String uri = (String) eventMap.get("uri");
                 eventMap.computeIfPresent("src_path", (k, v) -> ((String) v).replace(uri, ""));
                 eventMap.computeIfPresent("dst_path", (k, v) -> ((String) v).replace(uri, ""));

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReader.java
@@ -111,6 +111,15 @@ public final class ElasticSearchReader {
         } else {
             Map<String, Object> eventMap = ProtoConcatenator.concatToMap(Arrays.asList(msg.getHeader(), msg.getBody()), true);
             eventMap.put("event_type", msgType);
+
+            // Specific normalization for FS_EVENT
+            if ("FS_EVENT".equals(msgType)) {
+                String uri = (String) eventMap.get("uri");
+                eventMap.computeIfPresent("src_path", (k, v) -> ((String) v).replace(uri, ""));
+                eventMap.computeIfPresent("dst_path", (k, v) -> ((String) v).replace(uri, ""));
+                eventMap.computeIfPresent("uri", (k, v) -> UriHelper.getUniformizedUri((String) v));
+            }
+
             addEventToBulkProcessor(eventMap, msg.getTimestamp(), msg.getCommittableOffset());
         }
     }


### PR DESCRIPTION
Due to this bug uri can be different for same nameservice access and path can contain hdfs namenservice