### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,24 +76,24 @@
     <properties>
         <garmadon.version>1.2.0</garmadon.version>
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
-        <netty-all.version>4.1.30.Final</netty-all.version>
-        <bytebuddy.version>1.9.2</bytebuddy.version>
+        <netty-all.version>4.1.32.Final</netty-all.version>
+        <bytebuddy.version>1.9.7</bytebuddy.version>
         <spark.version>2.3.2</spark.version>
-        <es.version>6.5.3</es.version>
+        <es.version>6.5.4</es.version>
         <logback.version>1.2.3</logback.version>
-        <prometheus.version>0.5.0</prometheus.version>
+        <prometheus.version>0.6.0</prometheus.version>
         <maria-java-client.version>2.2.6</maria-java-client.version>
-        <oshi.version>3.9.1</oshi.version>
+        <oshi.version>3.12.1</oshi.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <slf4j.version>1.7.25</slf4j.version>
         <protobuf.version>3.6.1</protobuf.version>
         <kafka.version>0.10.2.1</kafka.version>
         <guava.version>20.0</guava.version>
-        <parquet-protobuf.version>1.8.1</parquet-protobuf.version>
-        <protobuf-dynamic.version>0.9.4</protobuf-dynamic.version>
-        <jackson.version>2.9.7</jackson.version>
+        <parquet-protobuf.version>1.8.3</parquet-protobuf.version>
+        <protobuf-dynamic.version>1.0.0</protobuf-dynamic.version>
+        <jackson.version>2.9.8</jackson.version>
         <commons-io.version>2.6</commons-io.version>
-        <presto.version>0.206</presto.version>
+        <presto.version>0.215</presto.version>
 
         <!-- tests -->
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
                 <configuration>
                     <environmentVariables>
                         <USER>userprobes</USER>
@@ -245,7 +245,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/readers/elasticsearch/pom.xml
+++ b/readers/elasticsearch/pom.xml
@@ -123,11 +123,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/readers/hdfs/pom.xml
+++ b/readers/hdfs/pom.xml
@@ -75,19 +75,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-auth</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- Garmadon -->
         <dependency>
@@ -146,11 +133,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0.2</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/scripts/launch_docker_platform.sh
+++ b/scripts/launch_docker_platform.sh
@@ -92,4 +92,14 @@ docker-compose exec client /opt/spark/bin/spark-submit \
     --conf spark.dynamicAllocation.minExecutors=1 --conf spark.dynamicAllocation.initialExecutors=4 \
     --conf spark.dynamicAllocation.maxExecutors=4 --conf spark.dynamicAllocation.executorIdleTimeout=1s \
     --class org.apache.spark.examples.sql.SparkSQLExample /opt/spark/examples/jars/spark-examples_2.11-${SPARK_VERSION}.jar
+
+# Exemple to select data from hdfs reader parquet table
+# docker-compose exec -ti client /opt/spark/bin/spark-shell \
+#    --deploy-mode client
+#
+#		import spark.implicits._
+#		val parquetFileDF = spark.read.parquet("/tmp/hdfs-exporter/final/application_event/2019-01-14")
+#		parquetFileDF.createOrReplaceTempView("parquetFile")
+#		val namesDF = spark.sql("SELECT * FROM parquetFile")
+#		namesDF.show(10)
 popd

--- a/test/src/main/docker/docker-compose.yml
+++ b/test/src/main/docker/docker-compose.yml
@@ -180,6 +180,26 @@ services:
        aliases:
          - elasticsearch-reader
 
+  hdfs-reader:
+    build: garmadon
+    image: garmadon:latest
+    hostname: hdfs-reader
+    restart: always
+    command:
+      - /usr/bin/entrypoint.sh
+      - hdfs-reader
+    volumes:
+      - ../../../../readers/hdfs/target/garmadon-readers-hdfs-${GARMADON_RELEASE}.jar:/opt/garmadon/lib/garmadon-readers-hdfs.jar
+    env_file: .env
+    depends_on:
+      - kafka
+      - namenode
+      - datanode
+    networks:
+      nwk:
+        aliases:
+          - hdfs-reader
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_RELEASE}
     hostname: elasticsearch

--- a/test/src/main/docker/garmadon/scripts/entrypoint.sh
+++ b/test/src/main/docker/garmadon/scripts/entrypoint.sh
@@ -33,6 +33,16 @@ function es-reader {
          com.criteo.hadoop.garmadon.elasticsearch.ElasticSearchReader kafka:9092 es-reader elasticsearch 9200 garmadon esuser espassword 31001
 }
 
+function hdfs-reader {
+    check_namenode_up
+    java -cp /opt/garmadon/lib/garmadon-readers-hdfs.jar:$(/opt/hadoop/bin/hadoop classpath) \
+         -DmessagesBeforeExpiringWriters=500 \
+         -DwritersExpirationDelay=1 \
+         -DexpirerPeriod=1 \
+         -DsizeBeforeFlushingTmp=1 \
+         com.criteo.hadoop.garmadon.hdfs.HdfsExporter kafka:9092 hdfs-reader /tmp/hdfs-exporter/temp /tmp/hdfs-exporter/final/ 31001
+}
+
 function namenode {
     hdfs namenode -format -force
     hdfs namenode
@@ -79,6 +89,9 @@ case $1 in
         ;;
     es-reader)
         es-reader
+        ;;
+    hdfs-reader)
+        hdfs-reader
         ;;
     namenode)
         namenode


### PR DESCRIPTION
Bump dependencies + add hdfs reader on docker test platform:
Netty from 4.1.30 to 4.1.32:
  https://netty.io/news/2018/10/30/4-1-31-Final.html
  https://netty.io/news/2018/11/29/4-1-32-Final.html
Bytebuddy from 1.9.2 to 1.9.7:
  https://github.com/raphw/byte-buddy/blob/master/release-notes.md
Prometheus client from 0.5.0 to 0.6.0
Oshi from 3.9.1 too 3.12.1:
  https://github.com/oshi/oshi/blob/master/CHANGELOG.md
Parquet-protobuf from 1.8.1 to 1.8.3:
  https://github.com/apache/parquet-mr/blob/master/CHANGES.md
Protobuf-dynamic from 0.9.4 to 1.0.0:
  https://github.com/os72/protobuf-dynamic/blob/master/RELEASE_NOTES.md
Elasticsearch from 6.5.3 to 6.5.4
  https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-6.5.4.html
Jackson from 2.9.7 to 2.9.8
  https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8
Presto from 0.206 to 0.215