### PR TITLE
Support kafka cluster migration in reader-hdfs

### DIFF
--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/configurations/KafkaConfiguration.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/configurations/KafkaConfiguration.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 
 public class KafkaConfiguration {
     private Properties settings = new Properties();
+    private String cluster = null;
 
     public Properties getSettings() {
         return settings;
@@ -11,5 +12,13 @@ public class KafkaConfiguration {
 
     public void setSettings(Properties settings) {
         this.settings = settings;
+    }
+
+    public String getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(String cluster) {
+        this.cluster = cluster;
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
@@ -133,7 +133,7 @@ public class HdfsExporter {
             final Class<? extends Message> clazz = out.getValue().getValue();
             final Function<LocalDateTime, ExpiringConsumer<Message>> consumerBuilder;
             final Path finalEventDir = new Path(finalHdfsDir, eventName);
-            final OffsetComputer offsetComputer = new HdfsOffsetComputer(fs, finalEventDir);
+            final OffsetComputer offsetComputer = new HdfsOffsetComputer(fs, finalEventDir, config.getKafka().getCluster());
 
             consumerBuilder = buildMessageConsumerBuilder(fs, new Path(temporaryHdfsDir, eventName),
                     finalEventDir, clazz, offsetComputer, pauser, eventName);

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HdfsOffsetComputer.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HdfsOffsetComputer.java
@@ -8,82 +8,78 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Persist and read offset based on HDFS file names, named _date_/_partition_._offset_
  */
 public class HdfsOffsetComputer implements OffsetComputer {
     private static final Logger LOGGER = LoggerFactory.getLogger(HdfsOffsetComputer.class);
-    private final Function<Integer, Pattern> offsetFilePatternGenerator;
+    private final Pattern offsetFilePatternGenerator;
     private final FileSystem fs;
     private final Path basePath;
+    private final String kafkaCluster;
+
+    public HdfsOffsetComputer(FileSystem fs, Path basePath) {
+        this(fs, basePath, null);
+    }
 
     /**
      * @param fs                            Filesystem for said files
      * @param basePath                      Root directory to look in for offsets filenames
+     * @param kafkaCluster                  Name of corresponding kafka cluster
      */
-    public HdfsOffsetComputer(FileSystem fs, Path basePath) {
+    public HdfsOffsetComputer(FileSystem fs, Path basePath, @Nullable String kafkaCluster) {
         this.fs = fs;
         this.basePath = basePath;
-        this.offsetFilePatternGenerator = partitionId -> Pattern.compile(String.format("^%d.(\\d+)$", partitionId));
+        this.kafkaCluster = kafkaCluster;
+        if (kafkaCluster == null) {
+            this.offsetFilePatternGenerator = Pattern.compile("^(\\d+)\\.(\\d+)$");
+        } else {
+            this.offsetFilePatternGenerator = Pattern.compile(String.format("^(\\d+)\\.cluster=%s\\.(\\d+)$", kafkaCluster));
+        }
     }
 
     @Override
     public Map<Integer, Long> computeOffsets(Collection<Integer> partitionIds) throws IOException {
+        Set<Integer> partitionIdsSet = new HashSet<>(partitionIds);
         final RemoteIterator<LocatedFileStatus> filesIterator = fs.listFiles(basePath, true);
-        final Collection<String> fileNames = new ArrayList<>();
-        final Map<Integer, Long> result = new HashMap<>();
+        final Map<Integer, Long> result = partitionIds.stream().collect(Collectors.toMap(Function.identity(), i -> NO_OFFSET));
 
         while (filesIterator.hasNext()) {
-            fileNames.add(filesIterator.next().getPath().getName());
+            String fileName = filesIterator.next().getPath().getName();
+            Matcher matcher = offsetFilePatternGenerator.matcher(fileName);
+            if (matcher.matches()) {
+                try {
+                    int partitionId = Integer.parseInt(matcher.group(1));
+                    Long offset = Long.parseLong(matcher.group(2));
+                    if (partitionIdsSet.contains(partitionId)) {
+                        result.merge(partitionId, offset, Long::max);
+                    }
+                } catch (NumberFormatException e) {
+                    LOGGER.info("Couldn't deviate a valid offset from '{}'", fileName);
+                }
+            }
         }
-
-        for (int partitionId: partitionIds) {
-            result.put(partitionId, computeOffset(partitionId, fileNames));
-        }
-
         return result;
-    }
-
-    private long computeOffset(int partitionId, Collection<String> fileNames) {
-        final Pattern partitionBasedPattern = offsetFilePatternGenerator.apply(partitionId);
-        long highestOffset = NO_OFFSET;
-
-        for (String fileName: fileNames) {
-            final Matcher matcher = partitionBasedPattern.matcher(fileName);
-            if (!matcher.matches() || matcher.groupCount() < 1) continue;
-
-            final String offsetString = matcher.group(1);
-            final long offset;
-
-            try {
-                 offset = Long.valueOf(offsetString);
-            } catch (NumberFormatException e) {
-                LOGGER.info("Couldn't deviate a valid offset from '{}'", offsetString);
-                continue;
-            }
-
-            if (offset > highestOffset) {
-                highestOffset = offset;
-            }
-        }
-
-        return highestOffset;
     }
 
     @Override
     public String computePath(LocalDateTime time, Offset offset) {
-        return String.format("%s/%d.%d", time.format(DateTimeFormatter.ISO_DATE), offset.getPartition(),
-                offset.getOffset());
+        if (kafkaCluster == null) {
+            return String.format("%s/%d.%d", time.format(DateTimeFormatter.ISO_DATE), offset.getPartition(),
+                    offset.getOffset());
+        } else {
+            return String.format("%s/%d.cluster=%s.%d", time.format(DateTimeFormatter.ISO_DATE), offset.getPartition(),
+                    kafkaCluster, offset.getOffset());
+        }
     }
 }

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HdfsOffsetComputerTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HdfsOffsetComputerTest.java
@@ -59,6 +59,15 @@ public class HdfsOffsetComputerTest {
     }
 
     @Test
+    public void migrationToClusterInfo() throws IOException {
+        performSinglePartitionTest(Arrays.asList("123.12", "123.cluster=pa4.13"), 123, 13, "pa4");
+        performSinglePartitionTest(Arrays.asList("123.12", "123.cluster=pa4.13"), 123, 12);
+
+        performSinglePartitionTest(Arrays.asList("42.23", "42.cluster=pa4.22"), 42, 22, "pa4");
+        performSinglePartitionTest(Arrays.asList("42.23", "42.cluster=pa4.22"), 42, 23);
+    }
+
+    @Test
     public void matchingPatternAmongMultiplePartitions() throws IOException {
         final HdfsOffsetComputer offsetComputer = new HdfsOffsetComputer(buildFileSystem(
                 Arrays.asList("456.12", "123.12", "456.24")),
@@ -119,10 +128,14 @@ public class HdfsOffsetComputerTest {
         }
     }
 
-    private void performSinglePartitionTest(List<String> fileNames, int partitionId, long expectedOffset)
+    private void performSinglePartitionTest(List<String> fileNames, int partitionId, long expectedOffset) throws IOException {
+        performSinglePartitionTest(fileNames, partitionId, expectedOffset, null);
+    }
+
+    private void performSinglePartitionTest(List<String> fileNames, int partitionId, long expectedOffset, String kafkaCluster)
             throws IOException {
         final HdfsOffsetComputer offsetComputer = new HdfsOffsetComputer(buildFileSystem(fileNames),
-                new Path("Fake path"));
+                new Path("Fake path"), kafkaCluster);
 
         Assert.assertEquals(expectedOffset,
                 offsetComputer.computeOffsets(Collections.singleton(partitionId)).get(partitionId).longValue());


### PR DESCRIPTION
Add kafka cluster name in file naming convention.
Be backward compatible.
if kafka.cluster is defined use it for file pattern
else use the old pattern