### PR TITLE
Ensure reported metric for memory/vcore usage is greater than 0

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/nodemanager/ContainerResourceMonitoringTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/nodemanager/ContainerResourceMonitoringTracer.java
@@ -83,9 +83,11 @@ public class ContainerResourceMonitoringTracer {
                         .withContainerID(containerID)
                         .build();
 
+                long memUsage = (currentMemUsage > 0) ? currentMemUsage : 0;
+
                 ContainerEventProtos.ContainerResourceEvent event = ContainerEventProtos.ContainerResourceEvent.newBuilder()
                         .setType(ContainerType.MEMORY.name())
-                        .setValue(currentMemUsage)
+                        .setValue(memUsage)
                         .setLimit(limit)
                         .build();
                 eventHandler.accept(System.currentTimeMillis(), header, event);
@@ -143,7 +145,7 @@ public class ContainerResourceMonitoringTracer {
                     String applicationId = applicationAttemptId.getApplicationId().toString();
                     String attemptId = applicationAttemptId.toString();
 
-                    float cpuVcoreUsed = (float) milliVcoresUsed / 1000;
+                    float cpuVcoreUsed = (milliVcoresUsed > 0) ? (float) milliVcoresUsed / 1000 : 0f;
                     int cpuVcoreLimit = ((ContainerMetrics) containerMetrics).cpuVcoreLimit.value();
 
                     Header header = Header.newBuilder()

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-compute.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-compute.json
@@ -157,7 +157,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           },
           {
@@ -165,7 +165,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           }
         ],
@@ -293,7 +293,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           },
           {
@@ -301,7 +301,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           }
         ],
@@ -429,7 +429,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           },
           {
@@ -437,7 +437,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           }
         ],
@@ -567,7 +567,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           },
           {
@@ -575,7 +575,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           }
         ],
@@ -705,7 +705,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           },
           {
@@ -713,7 +713,7 @@
             "label": null,
             "logBase": 1,
             "max": null,
-            "min": null,
+            "min": "0",
             "show": true
           }
         ],
@@ -841,7 +841,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -849,7 +849,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -962,7 +962,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -970,7 +970,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1083,7 +1083,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1091,7 +1091,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1223,7 +1223,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1231,7 +1231,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1350,7 +1350,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1358,7 +1358,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1490,7 +1490,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1498,7 +1498,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1629,7 +1629,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1637,7 +1637,7 @@
                 "label": null,
                 "logBase": 1,
                 "max": null,
-                "min": null,
+                "min": "0",
                 "show": true
               }
             ],
@@ -1677,7 +1677,6 @@
         {
           "allValue": "*",
           "current": {
-            "tags": [],
             "text": "All",
             "value": "$__all"
           },


### PR DESCRIPTION
Metric reported by nodemanager at container startup or end is sometimes a negative value
which make Total Vcore usage wrong