### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,16 +83,16 @@
     <properties>
         <garmadon.version>1.3.0</garmadon.version>
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
-        <netty-all.version>4.1.32.Final</netty-all.version>
-        <bytebuddy.version>1.9.7</bytebuddy.version>
-        <spark.version>2.3.2</spark.version>
-        <es.version>6.5.4</es.version>
+        <netty-all.version>4.1.33.Final</netty-all.version>
+        <bytebuddy.version>1.9.10</bytebuddy.version>
+        <spark.version>2.3.3</spark.version>
+        <es.version>6.6.1</es.version>
         <logback.version>1.2.3</logback.version>
         <prometheus.version>0.6.0</prometheus.version>
         <maria-java-client.version>2.2.6</maria-java-client.version>
-        <oshi.version>3.12.1</oshi.version>
+        <oshi.version>3.13.0</oshi.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <protobuf.version>3.6.1</protobuf.version>
         <kafka.version>2.0.1</kafka.version>
         <guava.version>20.0</guava.version>
@@ -101,7 +101,7 @@
         <jackson.version>2.9.8</jackson.version>
         <commons-io.version>2.6</commons-io.version>
         <flink.version>1.6.4</flink.version>
-        <presto.version>0.215</presto.version>
+        <presto.version>0.217</presto.version>
         <assertj.version>3.11.1</assertj.version>
         <consul.version>1.4.2</consul.version>
 

--- a/test/src/main/docker/garmadon/Dockerfile
+++ b/test/src/main/docker/garmadon/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH=${JAVA_HOME}/bin:/opt/hadoop/bin:/opt/spark/bin:/opt/flink/bin:$PATH
 
 # Environment Version
 ENV HADOOP_VERSION=2.6.0-cdh5.15.0
-ENV SPARK_VERSION=2.3.2
+ENV SPARK_VERSION=2.3.3
 ENV FLINK_VERSION=1.6.4
 
 # Environment Config


### PR DESCRIPTION
Netty from 4.1.32 to 4.1.33
  https://netty.io/news/2019/01/21/4-1-33-Final.html
Byte Buddy from 1.9.7 to 1.9.10
  https://github.com/raphw/byte-buddy/blob/master/release-notes.md
Spark from 2.3.2 to 2.3.3
Elasticsearch 6.5.4 to 6.6.1
  https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html
Oshi from 3.12.1 to 3.13.0
  https://github.com/oshi/oshi/blob/master/CHANGELOG.md
Slf4j from 1.7.25 to 1.7.26
  https://www.slf4j.org/news.html
Presto from 0.215 to 0.217