### PR TITLE
[HDFS EXPORTER] Output the exception when failing to close a consumer

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -269,7 +269,7 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
                 consumer.close();
                 return true;
             } catch (IOException e) {
-                LOGGER.error("Couldn't close writer for {} ({}/{}): {}", eventName, retry, maxAttempts, e.getMessage());
+                LOGGER.error(String.format("Couldn't close writer for %s (%d/%d)", eventName, retry, maxAttempts), e);
             }
         }
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -269,7 +269,7 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
                 consumer.close();
                 return true;
             } catch (IOException e) {
-                LOGGER.error("Couldn't close writer for {} ({}/{})", eventName, retry, maxAttempts, e);
+                LOGGER.error("Couldn't close writer for {} ({}/{}): {}", eventName, retry, maxAttempts, e.getMessage());
             }
         }
 


### PR DESCRIPTION
Next step would be to fail the app when failing too often. Otherwise a given even type could be
lagging behind by too much