### PR TITLE
Remove temporary hdfs folder at reader shutdown

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
@@ -67,8 +67,6 @@ public class HdfsExporter {
     private static Duration tmpFileOpenRetryPeriod;
     private static int sizeBeforeFlushingTmp;
 
-    private static FileSystem fs;
-
     protected HdfsExporter() {
         throw new UnsupportedOperationException();
     }
@@ -90,22 +88,13 @@ public class HdfsExporter {
         final String baseTemporaryHdfsDir = config.getHdfs().getBaseTemporaryDir();
         final Path finalHdfsDir = new Path(config.getHdfs().getFinalDir());
 
+        FileSystem fs = null;
         try {
             fs = finalHdfsDir.getFileSystem(HDFS_CONF);
         } catch (IOException e) {
             LOGGER.error("Could not initialize HDFS", e);
             exit(1);
         }
-
-        // Add Shutdown Hook to close FS and delete temp folders
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                fs.close();
-            } catch (IOException e) {
-                LOGGER.error("Could not close FS", e);
-                exit(1);
-            }
-        }));
 
         final Properties props = new Properties();
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/FileSystemUtils.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/FileSystemUtils.java
@@ -13,9 +13,9 @@ public final class FileSystemUtils {
     /**
      * Ensure paths exist and are directories. Otherwise create them.
      *
-     * @param dirs Directories that need to exist
-     * @param fs   Filesystem to which these directories should belong
-     * @throws IOException When failing to create any of the directories
+     * @param dirs          Directories that need to exist
+     * @param fs            Filesystem to which these directories should belong
+     * @throws IOException  When failing to create any of the directories
      */
     public static void ensureDirectoriesExist(Collection<Path> dirs, FileSystem fs) throws IOException {
         for (Path dir : dirs) {

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/FileSystemUtils.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/FileSystemUtils.java
@@ -13,9 +13,9 @@ public final class FileSystemUtils {
     /**
      * Ensure paths exist and are directories. Otherwise create them.
      *
-     * @param dirs          Directories that need to exist
-     * @param fs            Filesystem to which these directories should belong
-     * @throws IOException  When failing to create any of the directories
+     * @param dirs Directories that need to exist
+     * @param fs   Filesystem to which these directories should belong
+     * @throws IOException When failing to create any of the directories
      */
     public static void ensureDirectoriesExist(Collection<Path> dirs, FileSystem fs) throws IOException {
         for (Path dir : dirs) {


### PR DESCRIPTION
Currently folders in hdfs temp folder based on UUID are never deleted leading
to lots of files/folders beeing kept on hdfs
On normal run we must ensure that those folders are reclaimed at shutdown