### PR TITLE
Add fs event status

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
@@ -317,7 +317,7 @@ public class FileSystemTracer {
         DataAccessEventProtos.FsEvent.Status status = DataAccessEventProtos.FsEvent.Status.SUCCESS;
         try {
             Object result = zuper.call();
-            if(Boolean.FALSE.equals(result)){
+            if (Boolean.FALSE.equals(result)) {
                 status = DataAccessEventProtos.FsEvent.Status.FAILURE;
             }
             return result;

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
@@ -326,7 +326,8 @@ public class FileSystemTracer {
         }
     }
 
-    private static void sendFsEvent(String uri, String src, String dst, String fsAction, String username, long durationMillis, DataAccessEventProtos.FsEvent.Status status) {
+    private static void sendFsEvent(String uri, String src, String dst, String fsAction, String username, long durationMillis,
+                                    DataAccessEventProtos.FsEvent.Status status) {
         DataAccessEventProtos.FsEvent.Builder eventBuilder = DataAccessEventProtos.FsEvent
                 .newBuilder();
 

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
@@ -314,24 +314,27 @@ public class FileSystemTracer {
 
     private static Object executeMethod(@SuperCall Callable<?> zuper, String uri, String src, String dst, String fsAction, String username) throws Exception {
         long startTime = System.nanoTime();
+        DataAccessEventProtos.FsEvent.Status status = DataAccessEventProtos.FsEvent.Status.SUCCESS;
         try {
             return zuper.call();
         } catch (Exception e) {
+            status = DataAccessEventProtos.FsEvent.Status.FAILURE;
             throw e;
         } finally {
             long elapsedTime = (System.nanoTime() - startTime) / NANOSECONDS_PER_MILLISECOND;
-            sendFsEvent(uri, src, dst, fsAction, username, elapsedTime);
+            sendFsEvent(uri, src, dst, fsAction, username, elapsedTime, status);
         }
     }
 
-    private static void sendFsEvent(String uri, String src, String dst, String fsAction, String username, long durationMillis) {
+    private static void sendFsEvent(String uri, String src, String dst, String fsAction, String username, long durationMillis, DataAccessEventProtos.FsEvent.Status status) {
         DataAccessEventProtos.FsEvent.Builder eventBuilder = DataAccessEventProtos.FsEvent
                 .newBuilder();
 
         eventBuilder.setAction(fsAction)
                 .setDstPath(dst)
                 .setUri(uri)
-                .setMethodDurationMillis(durationMillis);
+                .setMethodDurationMillis(durationMillis)
+                .setStatus(status);
 
         if (username != null) {
             eventBuilder.setHdfsUser(username);

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracer.java
@@ -316,7 +316,11 @@ public class FileSystemTracer {
         long startTime = System.nanoTime();
         DataAccessEventProtos.FsEvent.Status status = DataAccessEventProtos.FsEvent.Status.SUCCESS;
         try {
-            return zuper.call();
+            Object result = zuper.call();
+            if(Boolean.FALSE.equals(result)){
+                status = DataAccessEventProtos.FsEvent.Status.FAILURE;
+            }
+            return result;
         } catch (Exception e) {
             status = DataAccessEventProtos.FsEvent.Status.FAILURE;
             throw e;

--- a/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracerTest.java
+++ b/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/hdfs/FileSystemTracerTest.java
@@ -255,7 +255,7 @@ public class FileSystemTracerTest {
 
     @Test
     @AgentAttachmentRule.Enforce
-    public void FileSystemTracer_should_indicate_if_event_is_success_or_failure() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void FileSystemTracer_should_indicate_if_event_is_failure() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method create = clazzFS.getMethod("create", Path.class,
                 FsPermission.class,
                 boolean.class,

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
@@ -80,19 +80,19 @@ public class ProtoConcatenator {
      */
     public static Map<String, Object> concatToMap(long timestampMillis, Collection<Message> messages, boolean includeDefaultValueFields) {
         return concatInner(messages,
-                keys -> {
-                    Map<String, Object> concatMap = new HashMap<>(keys.size());
-                    if (includeDefaultValueFields) {
-                        for (Descriptors.FieldDescriptor fieldDescriptor : keys) {
-                            concatMap.put(fieldDescriptor.getName(), getRealFieldValue(fieldDescriptor.getDefaultValue()));
-                        }
+            keys -> {
+                Map<String, Object> concatMap = new HashMap<>(keys.size());
+                if (includeDefaultValueFields) {
+                    for (Descriptors.FieldDescriptor fieldDescriptor : keys) {
+                        concatMap.put(fieldDescriptor.getName(), getRealFieldValue(fieldDescriptor.getDefaultValue()));
                     }
-                    concatMap.put(TIMESTAMP_FIELD_NAME, timestampMillis);
-                    return concatMap;
-                },
-                (entry, eventMap) -> {
-                    eventMap.put(entry.getKey().getName(), getRealFieldValue(entry.getValue()));
-                });
+                }
+                concatMap.put(TIMESTAMP_FIELD_NAME, timestampMillis);
+                return concatMap;
+            },
+            (entry, eventMap) -> {
+                eventMap.put(entry.getKey().getName(), getRealFieldValue(entry.getValue()));
+            });
     }
 
     /**
@@ -110,15 +110,15 @@ public class ProtoConcatenator {
 
         //Add Enum definitions before adding fields
         fields
-                .stream()
-                .filter(fd -> Descriptors.FieldDescriptor.Type.ENUM.equals(fd.getType()))
-                .map(Descriptors.FieldDescriptor::getEnumType)
-                .distinct()
-                .forEach(enumDescriptor -> {
-                    EnumDefinition.Builder enumDefinitionBuilder = EnumDefinition.newBuilder(enumDescriptor.getName());
-                    enumDescriptor.getValues().forEach(desc -> enumDefinitionBuilder.addValue(desc.getName(), desc.getNumber()));
-                    msgDef.addEnumDefinition(enumDefinitionBuilder.build());
-                });
+            .stream()
+            .filter(fd -> Descriptors.FieldDescriptor.Type.ENUM.equals(fd.getType()))
+            .map(Descriptors.FieldDescriptor::getEnumType)
+            .distinct()
+            .forEach(enumDescriptor -> {
+                EnumDefinition.Builder enumDefinitionBuilder = EnumDefinition.newBuilder(enumDescriptor.getName());
+                enumDescriptor.getValues().forEach(desc -> enumDefinitionBuilder.addValue(desc.getName(), desc.getNumber()));
+                msgDef.addEnumDefinition(enumDefinitionBuilder.build());
+            });
 
         int currentIndex = 1;
 

--- a/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
+++ b/readers/common/src/test/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenatorTest.java
@@ -210,8 +210,9 @@ public class ProtoConcatenatorTest {
         expectedValues.put("the_enum_1", "TEST_1");
         expectedValues.put("the_enum_2", "DEFAULT");
         expectedValues.put(ProtoConcatenator.TIMESTAMP_FIELD_NAME, 0L);
+        expectedValues.put(ProtoConcatenator.KAFKA_OFFSET, 0L);
 
-        testAllOutTypesWith(0L, Collections.singletonList(msg), expectedValues);
+        testAllOutTypesWith(0L, Collections.singletonList(msg), expectedValues, 0L);
     }
 
     /**

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
@@ -906,7 +906,7 @@
                 "type": "date_histogram"
               }
             ],
-            "hide": true,
+            "hide": false,
             "metrics": [
               {
                 "field": "select field",
@@ -932,7 +932,7 @@
                 "type": "date_histogram"
               }
             ],
-            "hide": true,
+            "hide": false,
             "metrics": [
               {
                 "field": "select field",

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
@@ -758,6 +758,10 @@
           {
             "text": "dst_path",
             "value": "dst_path"
+          },
+          {
+            "text": "status",
+            "value": "status"
           }
         ],
         "datasource": "$datasource",
@@ -821,6 +825,165 @@
         "title": "",
         "transform": "json",
         "type": "table"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 7,
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 27
+        },
+        "id": 156,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "paceLength": 10,
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+          {
+            "alias": "standalone",
+            "bucketAggs": [
+              {
+                "field": "timestamp",
+                "id": "2",
+                "settings": {
+                  "interval": "auto",
+                  "min_doc_count": 0,
+                  "trimEdges": 0
+                },
+                "type": "date_histogram"
+              }
+            ],
+            "hide": false,
+            "metrics": [
+              {
+                "field": "select field",
+                "id": "1",
+                "meta": {},
+                "settings": {},
+                "type": "count"
+              }
+            ],
+            "query": "event_type:FS_EVENT AND uri:$uri AND dst_path:$path AND status: FAILURE AND tags: STANDALONE",
+            "refId": "A",
+            "timeField": "timestamp"
+          },
+          {
+            "alias": "yarn container",
+            "bucketAggs": [
+              {
+                "field": "timestamp",
+                "id": "2",
+                "settings": {
+                  "interval": "auto",
+                  "min_doc_count": 0,
+                  "trimEdges": 0
+                },
+                "type": "date_histogram"
+              }
+            ],
+            "hide": true,
+            "metrics": [
+              {
+                "field": "select field",
+                "id": "1",
+                "type": "count"
+              }
+            ],
+            "query": "event_type:FS_EVENT AND uri:$uri AND dst_path:$path AND status: FAILURE AND tags: YARN_APPLICATION",
+            "refId": "B",
+            "timeField": "timestamp"
+          },
+          {
+            "alias": "gateway",
+            "bucketAggs": [
+              {
+                "field": "timestamp",
+                "id": "2",
+                "settings": {
+                  "interval": "auto",
+                  "min_doc_count": 0,
+                  "trimEdges": 0
+                },
+                "type": "date_histogram"
+              }
+            ],
+            "hide": true,
+            "metrics": [
+              {
+                "field": "select field",
+                "id": "1",
+                "type": "count"
+              }
+            ],
+            "query": "event_type:FS_EVENT AND uri:$uri AND dst_path:$path AND status: FAILURE AND tags: GATEWAY",
+            "refId": "C",
+            "timeField": "timestamp"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Failures",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
       },
       {
         "collapsed": true,

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-hdfs.json
@@ -832,6 +832,7 @@
         "cacheTimeout": null,
         "dashLength": 10,
         "dashes": false,
+        "datasource": "$datasource",
         "fill": 7,
         "gridPos": {
           "h": 6,

--- a/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
+++ b/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
@@ -215,6 +215,7 @@ public class ElasticSearchReaderTest {
         eventMap.put("uri", "hdfs://data-preprod-pa4");
         eventMap.put("method_duration_millis", 100);
         eventMap.put("hdfs_user", "lakeprobes");
+        eventMap.put("status", "UNKNOWN");
 
         writeGarmadonMessage(type, event, 0L);
         verify(bulkProcessor, times(1)).add(argument.capture(), any(CommittableOffset.class));

--- a/schema/src/main/protobuf/data_access_event.proto
+++ b/schema/src/main/protobuf/data_access_event.proto
@@ -17,6 +17,12 @@ message FsEvent {
     string uri = 4;
     uint64 method_duration_millis = 5;
     string hdfs_user = 6;
+    enum Status {
+        UNKNOWN = 0;
+        FAILURE = 1;
+        SUCCESS = 2;
+    };
+    Status status = 7;
 }
 
 message StateEvent {


### PR DESCRIPTION
Uses enum with three value to help migration (UNKNOWN, FAILURE, SUCCESS). If we were only using a boolean, the default value would be false and there would be no way to distinguish an old event that succeeded from a new one that failed.