### PR TITLE
Add more JVM monitoring

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/ContainerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/ContainerHeader.java
@@ -3,6 +3,7 @@ package com.criteo.hadoop.garmadon.agent.headers;
 import com.criteo.hadoop.garmadon.schema.enums.Component;
 import com.criteo.hadoop.garmadon.schema.enums.Framework;
 import com.criteo.hadoop.garmadon.schema.events.Header;
+import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -30,7 +31,7 @@ public final class ContainerHeader {
     }
 
     private void setFrameworkComponent() {
-        String[] commands = Utils.getArrayJavaCommandLine();
+        String[] commands = HeaderUtils.getArrayJavaCommandLine();
         mainClass = commands[0];
         switch (mainClass) {
             // MAP_REDUCE
@@ -111,7 +112,7 @@ public final class ContainerHeader {
                 .withAttemptID(appAttemptID.toString())
                 .withUser(user)
                 .withContainerID(containerIdString)
-                .withPid(Utils.getPid())
+                .withPid(HeaderUtils.getPid())
                 .withFramework(framework.name())
                 .withComponent(component.name())
                 .withExecutorId(executorId)

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
@@ -15,7 +15,7 @@ public final class NodemanagerHeader {
             .withHostname(HeaderUtils.getHostname())
             .withUser(HeaderUtils.getUser())
             .withPid(HeaderUtils.getPid())
-            .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
+            .withMainClass(HeaderUtils.getJavaMainClass())
             .addTag(Header.Tag.NODEMANAGER.name())
             .addTags(System.getProperty("garmadon.tags"))
             .build();

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
@@ -1,6 +1,7 @@
 package com.criteo.hadoop.garmadon.agent.headers;
 
 import com.criteo.hadoop.garmadon.schema.events.Header;
+import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
 
 public final class NodemanagerHeader {
     private Header header;
@@ -11,12 +12,13 @@ public final class NodemanagerHeader {
 
     private Header createCachedHeader() {
         return Header.newBuilder()
-                .withHostname(Utils.getHostname())
-                .withUser(Utils.getUser())
-                .withPid(Utils.getPid())
-                .addTag(Header.Tag.NODEMANAGER.name())
-                .addTags(System.getProperty("garmadon.tags"))
-                .build();
+            .withHostname(HeaderUtils.getHostname())
+            .withUser(HeaderUtils.getUser())
+            .withPid(HeaderUtils.getPid())
+            .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
+            .addTag(Header.Tag.NODEMANAGER.name())
+            .addTags(System.getProperty("garmadon.tags"))
+            .build();
     }
 
     private static class SingletonHolder {

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
@@ -15,6 +15,7 @@ public final class RessourceManagerHeader {
                 .withHostname(HeaderUtils.getHostname())
                 .withUser(HeaderUtils.getUser())
                 .withPid(HeaderUtils.getPid())
+                .withMainClass(HeaderUtils.getJavaMainClass())
                 .addTag(Header.Tag.RESOURCEMANAGER.name())
                 .addTags(System.getProperty("garmadon.tags"))
                 .build();

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
@@ -1,6 +1,7 @@
 package com.criteo.hadoop.garmadon.agent.headers;
 
 import com.criteo.hadoop.garmadon.schema.events.Header;
+import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
 
 public final class RessourceManagerHeader {
     private Header header;
@@ -11,9 +12,9 @@ public final class RessourceManagerHeader {
 
     private Header createCachedHeader() {
         return Header.newBuilder()
-                .withHostname(Utils.getHostname())
-                .withUser(Utils.getUser())
-                .withPid(Utils.getPid())
+                .withHostname(HeaderUtils.getHostname())
+                .withUser(HeaderUtils.getUser())
+                .withPid(HeaderUtils.getPid())
                 .addTag(Header.Tag.RESOURCEMANAGER.name())
                 .addTags(System.getProperty("garmadon.tags"))
                 .build();

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
@@ -1,6 +1,7 @@
 package com.criteo.hadoop.garmadon.agent.headers;
 
 import com.criteo.hadoop.garmadon.schema.events.Header;
+import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
 
 public final class StandaloneHeader {
     private Header.SerializedHeader header;
@@ -12,13 +13,13 @@ public final class StandaloneHeader {
     private Header.SerializedHeader createCachedHeader() {
         //build the header for the whole application once
         return Header.newBuilder()
-                .withId(Utils.getStandaloneId())
+                .withId(HeaderUtils.getStandaloneId())
                 .addTag(Header.Tag.STANDALONE.name())
                 .addTags(System.getProperty("garmadon.tags"))
-                .withHostname(Utils.getHostname())
-                .withUser(Utils.getUser())
-                .withPid(Utils.getPid())
-                .withMainClass(Utils.getArrayJavaCommandLine()[0])
+                .withHostname(HeaderUtils.getHostname())
+                .withUser(HeaderUtils.getUser())
+                .withPid(HeaderUtils.getPid())
+                .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
                 .buildSerializedHeader();
     }
 

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
@@ -19,7 +19,7 @@ public final class StandaloneHeader {
                 .withHostname(HeaderUtils.getHostname())
                 .withUser(HeaderUtils.getUser())
                 .withPid(HeaderUtils.getPid())
-                .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
+                .withMainClass(HeaderUtils.getJavaMainClass())
                 .buildSerializedHeader();
     }
 

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/NodeManagerModule.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/NodeManagerModule.java
@@ -3,12 +3,16 @@ package com.criteo.hadoop.garmadon.agent.modules;
 import com.criteo.hadoop.garmadon.agent.AsyncEventProcessor;
 import com.criteo.hadoop.garmadon.agent.headers.NodemanagerHeader;
 import com.criteo.hadoop.garmadon.agent.tracers.hadoop.nodemanager.ContainerResourceMonitoringTracer;
+import com.criteo.hadoop.garmadon.agent.tracers.jvm.JVMStatisticsTracer;
 
 import java.lang.instrument.Instrumentation;
 
 public class NodeManagerModule implements GarmadonAgentModule {
     @Override
     public void setup(Instrumentation instrumentation, AsyncEventProcessor eventProcessor) {
+        JVMStatisticsTracer.setup((timestamp, event) ->
+            eventProcessor.offer(timestamp, NodemanagerHeader.getInstance().getBaseHeader(), event));
+
         ContainerResourceMonitoringTracer.setup(NodemanagerHeader.getInstance().getBaseHeader(),
                 instrumentation, eventProcessor);
     }

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/ResourceManagerModule.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/modules/ResourceManagerModule.java
@@ -3,12 +3,16 @@ package com.criteo.hadoop.garmadon.agent.modules;
 import com.criteo.hadoop.garmadon.agent.AsyncEventProcessor;
 import com.criteo.hadoop.garmadon.agent.headers.RessourceManagerHeader;
 import com.criteo.hadoop.garmadon.agent.tracers.hadoop.resourcemanager.RMAppTracer;
+import com.criteo.hadoop.garmadon.agent.tracers.jvm.JVMStatisticsTracer;
 
 import java.lang.instrument.Instrumentation;
 
 public class ResourceManagerModule implements GarmadonAgentModule {
     @Override
     public void setup(Instrumentation instrumentation, AsyncEventProcessor eventProcessor) {
+        JVMStatisticsTracer.setup((timestamp, event) ->
+            eventProcessor.offer(timestamp, RessourceManagerHeader.getInstance().getBaseHeader(), event));
+
         RMAppTracer.setup(RessourceManagerHeader.getInstance().getBaseHeader(),
                 instrumentation, eventProcessor);
     }

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -6,6 +6,7 @@ import com.criteo.hadoop.garmadon.forwarder.metrics.ForwarderEventSender;
 import com.criteo.hadoop.garmadon.forwarder.metrics.HostStatistics;
 import com.criteo.hadoop.garmadon.forwarder.metrics.PrometheusHttpMetrics;
 import com.criteo.hadoop.garmadon.schema.events.Header;
+import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -18,8 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Properties;
 
 public class Forwarder {
@@ -31,15 +30,7 @@ public class Forwarder {
     private static final String DEFAULT_FORWARDER_PORT = "31000";
     private static final String DEFAULT_PROMETHEUS_PORT = "31001";
 
-    private static String hostname;
-
-    static {
-        try {
-            hostname = InetAddress.getLocalHost().getCanonicalHostName();
-        } catch (UnknownHostException e) {
-            LOGGER.error("", e);
-        }
-    }
+    private static String hostname = HeaderUtils.getHostname();
 
     private final Properties properties;
 
@@ -56,6 +47,9 @@ public class Forwarder {
 
         Header.Builder headerBuilder = Header.newBuilder()
                 .withHostname(hostname)
+                .withPid(HeaderUtils.getPid())
+                .withUser(HeaderUtils.getUser())
+                .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
                 .addTag(Header.Tag.FORWARDER.name());
 
         for (String tag : properties.getProperty("forwarder.tags", "").split(",")) {

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -49,7 +49,7 @@ public class Forwarder {
                 .withHostname(hostname)
                 .withPid(HeaderUtils.getPid())
                 .withUser(HeaderUtils.getUser())
-                .withMainClass(HeaderUtils.getArrayJavaCommandLine()[0])
+                .withMainClass(HeaderUtils.getJavaMainClass())
                 .addTag(Header.Tag.FORWARDER.name());
 
         for (String tag : properties.getProperty("forwarder.tags", "").split(",")) {

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-jvm.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-jvm.json
@@ -2566,7 +2566,7 @@
           "datasource": "$datasource",
           "definition": "",
           "hide": 0,
-          "includeAll": false,
+          "includeAll": true,
           "label": null,
           "multi": false,
           "name": "pid",

--- a/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-jvm.json
+++ b/readers/elasticsearch/src/main/elasticsearch/grafana/garmadon-jvm.json
@@ -94,7 +94,7 @@
                 "type": "sum"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -203,7 +203,7 @@
                 "type": "avg"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -231,7 +231,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "B",
             "target": "",
             "timeField": "timestamp"
@@ -340,7 +340,7 @@
                 "type": "avg"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -449,7 +449,7 @@
                 "type": "avg"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -568,7 +568,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -605,7 +605,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "B",
             "target": "",
             "timeField": "timestamp"
@@ -654,7 +654,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "C",
             "target": "",
             "timeField": "timestamp"
@@ -691,7 +691,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "D",
             "target": "",
             "timeField": "timestamp"
@@ -728,7 +728,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "E",
             "target": "",
             "timeField": "timestamp"
@@ -765,7 +765,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "F",
             "target": "",
             "timeField": "timestamp"
@@ -874,7 +874,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "C",
             "target": "",
             "timeField": "timestamp"
@@ -902,7 +902,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "D",
             "target": "",
             "timeField": "timestamp"
@@ -930,7 +930,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -958,7 +958,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "B",
             "target": "",
             "timeField": "timestamp"
@@ -986,7 +986,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "E",
             "target": "",
             "timeField": "timestamp"
@@ -1014,7 +1014,7 @@
                 "type": "max"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "F",
             "target": "",
             "timeField": "timestamp"
@@ -1225,7 +1225,7 @@
                 "type": "raw_document"
               }
             ],
-            "query": "event_type:GC_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:GC_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "timeField": "timestamp"
           }
@@ -1297,7 +1297,7 @@
                 "type": "avg"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -1415,7 +1415,7 @@
                 "type": "derivative"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "B",
             "target": "",
             "timeField": "timestamp"
@@ -1524,7 +1524,7 @@
                 "type": "avg"
               }
             ],
-            "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+            "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
             "refId": "A",
             "target": "",
             "timeField": "timestamp"
@@ -1643,7 +1643,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "B",
                 "target": "",
                 "timeField": "timestamp"
@@ -1752,7 +1752,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -1861,7 +1861,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -1970,7 +1970,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -2080,7 +2080,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -2108,7 +2108,7 @@
                     "type": "avg"
                   }
                 ],
-                "query": "event_type:JVMSTATS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:JVMSTATS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "B",
                 "target": "",
                 "timeField": "timestamp"
@@ -2249,7 +2249,7 @@
                     "type": "count"
                   }
                 ],
-                "query": "event_type:FS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:FS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -2382,7 +2382,7 @@
                     "type": "percentiles"
                   }
                 ],
-                "query": "event_type:FS_EVENT AND tags:STANDALONE AND username:$username AND pid:$pid AND hostname:$hostname",
+                "query": "event_type:FS_EVENT AND tags:$tag AND username:$username AND pid:$pid AND hostname:$hostname",
                 "refId": "A",
                 "target": "",
                 "timeField": "timestamp"
@@ -2460,6 +2460,31 @@
         {
           "allValue": "*",
           "current": {
+            "text": "STANDALONE",
+            "value": "STANDALONE"
+          },
+          "datasource": "$datasource",
+          "definition": "{\"find\": \"terms\", \"field\": \"tags\"}",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "tag",
+          "options": [],
+          "query": "{\"find\": \"terms\", \"field\": \"tags\"}",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": "*",
+          "current": {
             "text": "client",
             "value": "client"
           },
@@ -2471,7 +2496,7 @@
           "multi": false,
           "name": "hostname",
           "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"hostname\", \"query\": \"tags:STANDALONE\", \"size\": 5000}",
+          "query": "{\"find\": \"terms\", \"field\": \"hostname\", \"query\": \"tags:$tag\", \"size\": 5000}",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2496,7 +2521,7 @@
           "multi": false,
           "name": "username",
           "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"username\", \"query\": \"tags:STANDALONE AND hostname:$hostname\", \"size\": 1000}",
+          "query": "{\"find\": \"terms\", \"field\": \"username\", \"query\": \"tags:$tag AND hostname:$hostname\", \"size\": 1000}",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2521,7 +2546,7 @@
           "multi": false,
           "name": "main_class",
           "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"main_class\", \"query\": \"tags:STANDALONE AND hostname:$hostname AND username:$username\", \"size\": 5000}",
+          "query": "{\"find\": \"terms\", \"field\": \"main_class\", \"query\": \"tags:$tag AND hostname:$hostname AND username:$username\", \"size\": 5000}",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2546,7 +2571,7 @@
           "multi": false,
           "name": "pid",
           "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"pid\", \"query\": \"tags:STANDALONE AND hostname:$hostname AND username:$username AND main_class:$main_class\", \"size\": 5000}",
+          "query": "{\"find\": \"terms\", \"field\": \"pid\", \"query\": \"tags:$tag AND hostname:$hostname AND username:$username AND main_class:$main_class\", \"size\": 5000}",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2571,7 +2596,7 @@
           "multi": false,
           "name": "uri",
           "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"uri\", \"query\": \"tags:STANDALONE AND hostname:$hostname AND pid:$pid AND main_class:$main_class\"}",
+          "query": "{\"find\": \"terms\", \"field\": \"uri\", \"query\": \"tags:$tag AND hostname:$hostname AND pid:$pid AND main_class:$main_class\"}",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2611,7 +2636,7 @@
       ]
     },
     "timezone": "",
-    "title": "Garmadon - StandAlone JVM",
+    "title": "Garmadon - JVM",
     "uid": null,
     "version": null
   }

--- a/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
+++ b/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
@@ -1,13 +1,13 @@
-package com.criteo.hadoop.garmadon.agent.headers;
+package com.criteo.hadoop.garmadon.schema.events;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public class Utils {
+public class HeaderUtils {
 
-    protected Utils() {
+    protected HeaderUtils() {
         throw new UnsupportedOperationException();
     }
 

--- a/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
+++ b/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
@@ -41,4 +41,8 @@ public class HeaderUtils {
         return System.getProperty("sun.java.command", "empty_class").split(" ");
     }
 
+    public static String getJavaMainClass() {
+        return getArrayJavaCommandLine()[0];
+    }
+
 }


### PR DESCRIPTION
 * Add a tag choice on JVM dashboard
 * Add missing header fields on forwarder (user, pid, java main class)
 * Turn on JVM statistics on NodeManagerModule
 * Add missing header field on nodemanager (java main class)

Replaces https://github.com/criteo/garmadon/pull/121