### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <protobuf.version>3.7.1</protobuf.version>
         <kafka.version>2.0.1</kafka.version>
         <guava.version>20.0</guava.version>
-        <parquet-protobuf.version>1.8.3</parquet-protobuf.version>
+        <parquet-protobuf.version>1.10.1</parquet-protobuf.version>
         <protobuf-dynamic.version>1.0.0</protobuf-dynamic.version>
         <jackson.version>2.9.8</jackson.version>
         <commons-io.version>2.6</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
     <properties>
         <garmadon.version>1.3.1</garmadon.version>
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
-        <netty-all.version>4.1.33.Final</netty-all.version>
-        <bytebuddy.version>1.9.10</bytebuddy.version>
-        <spark.version>2.3.3</spark.version>
+        <netty-all.version>4.1.35.Final</netty-all.version>
+        <bytebuddy.version>1.9.12</bytebuddy.version>
+        <spark.version>2.4.1</spark.version>
         <es.version>6.6.1</es.version>
         <logback.version>1.2.3</logback.version>
         <prometheus.version>0.6.0</prometheus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <oshi.version>3.13.0</oshi.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <protobuf.version>3.6.1</protobuf.version>
+        <protobuf.version>3.7.1</protobuf.version>
         <kafka.version>2.0.1</kafka.version>
         <guava.version>20.0</guava.version>
         <parquet-protobuf.version>1.8.3</parquet-protobuf.version>

--- a/readers/hdfs/pom.xml
+++ b/readers/hdfs/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>garmadon-readers-common</artifactId>
             <version>${garmadon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/test/src/main/docker/garmadon/Dockerfile
+++ b/test/src/main/docker/garmadon/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH=${JAVA_HOME}/bin:/opt/hadoop/bin:/opt/spark/bin:/opt/flink/bin:$PATH
 
 # Environment Version
 ENV HADOOP_VERSION=2.6.0-cdh5.15.0
-ENV SPARK_VERSION=2.3.3
+ENV SPARK_VERSION=2.4.1
 ENV FLINK_VERSION=1.6.4
 
 # Environment Config


### PR DESCRIPTION
Netty from 4.1.33 to 4.1.35
  https://netty.io/news/2019/03/08/4-1-34-Final.html
  https://netty.io/news/2019/04/17/4-1-35-Final.html
ByteBuddy from 1.9.10 to 1.9.12
  https://github.com/raphw/byte-buddy/blob/master/release-notes.md
Spark 2.3.3 to 2.4.1
Bump protobuf from 3.6.1 to 3.7.1 
Bump parquet protobuf 
  https://github.com/apache/parquet-mr/blob/master/CHANGES.md