### PR TITLE
Set header id on all events

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/NodemanagerHeader.java
@@ -12,6 +12,7 @@ public final class NodemanagerHeader {
 
     private Header createCachedHeader() {
         return Header.newBuilder()
+            .withId(HeaderUtils.getId())
             .withHostname(HeaderUtils.getHostname())
             .withUser(HeaderUtils.getUser())
             .withPid(HeaderUtils.getPid())

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/RessourceManagerHeader.java
@@ -12,6 +12,7 @@ public final class RessourceManagerHeader {
 
     private Header createCachedHeader() {
         return Header.newBuilder()
+                .withId(HeaderUtils.getId())
                 .withHostname(HeaderUtils.getHostname())
                 .withUser(HeaderUtils.getUser())
                 .withPid(HeaderUtils.getPid())

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/StandaloneHeader.java
@@ -13,7 +13,7 @@ public final class StandaloneHeader {
     private Header.SerializedHeader createCachedHeader() {
         //build the header for the whole application once
         return Header.newBuilder()
-                .withId(HeaderUtils.getStandaloneId())
+                .withId(HeaderUtils.getId())
                 .addTag(Header.Tag.STANDALONE.name())
                 .addTags(System.getProperty("garmadon.tags"))
                 .withHostname(HeaderUtils.getHostname())

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnable.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnable.java
@@ -38,6 +38,7 @@ public class RMContextImplEventRunnable implements Runnable {
                 rmContext.getRMApps().forEach((applicationId, rmApp) -> {
                     if (cacheFinishedApp.getIfPresent(applicationId.toString()) == null) {
                         Header header = Header.newBuilder()
+                                .withId(applicationId.toString())
                                 .withApplicationID(applicationId.toString())
                                 .withUser(rmApp.getUser())
                                 .withApplicationName(rmApp.getName())

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -46,6 +46,7 @@ public class Forwarder {
         this.properties = properties;
 
         Header.Builder headerBuilder = Header.newBuilder()
+                .withId(HeaderUtils.getId())
                 .withHostname(hostname)
                 .withPid(HeaderUtils.getPid())
                 .withUser(HeaderUtils.getUser())

--- a/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
+++ b/schema/src/main/java/com/criteo/hadoop/garmadon/schema/events/HeaderUtils.java
@@ -33,7 +33,7 @@ public class HeaderUtils {
         return pid;
     }
 
-    public static String getStandaloneId() {
+    public static String getId() {
         return getHostname() + ":" + getUser() + ":" + getPid();
     }
 


### PR DESCRIPTION
No id is set on NM and RM events which leads to all those events going to same
partition which can lead to slow/unballanced partition
No id is set on APPLICATION_EVENT froom resourcemanager which lead to not have
all events from an app_id on the same partition. We use this assumption on
heuristics readers and on ES readers to enrich data