### PR TITLE
Add hadoop 3 to docker test platform

### DIFF
--- a/scripts/launch_docker_platform.sh
+++ b/scripts/launch_docker_platform.sh
@@ -26,7 +26,6 @@ docker-compose down
 docker-compose up --build -d
 
 # Get spark and hadoop release
-HADOOP_VERSION=$(grep "ENV HADOOP_VERSION" garmadon/Dockerfile|cut -d= -f2)
 SPARK_VERSION=$(grep "ENV SPARK_VERSION" garmadon/Dockerfile|cut -d= -f2)
 popd
 
@@ -61,15 +60,15 @@ pushd ${DOCKER_COMPOSE_FOLDER}
 docker-compose exec client java -Dgarmadon.tags=version,presto-server -version
 
 # MapRed Teragen
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples.jar \
     teragen -Dmapreduce.job.tags=garmadonJobTagTeragen 1000000 /tmp/test/teragen
 
 # MapRed Terasort
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples.jar \
     terasort -Dmapreduce.job.tags=garmadonJobTagTeraSort /tmp/test/teragen /tmp/test/terasort
 
 # MapRed Pi
-docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce2/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar \
+docker-compose exec client yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples.jar \
     pi -Dmapreduce.job.tags=garmadonJobTagPi 2 1000
 
 # SparkPi (Compute)

--- a/test/src/main/docker/.env
+++ b/test/src/main/docker/.env
@@ -7,4 +7,5 @@ KAFKA_ADVERTISED_HOST_NAME=kafka
 KAFKA_ADVERTISED_PORT=9092
 KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
 # HADOOP
-HADOOP_LIBEXEC_DIR=/opt/hadoop/libexec
+# Update this parameter to select hadoop 2 or 3
+HADOOP_RELEASE=2

--- a/test/src/main/docker/garmadon/Dockerfile
+++ b/test/src/main/docker/garmadon/Dockerfile
@@ -14,15 +14,20 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
 ENV PATH=${JAVA_HOME}/bin:/opt/hadoop/bin:/opt/spark/bin:/opt/flink/bin:$PATH
 
 # Environment Version
-ENV HADOOP_VERSION=2.6.0-cdh5.15.0
+ENV HADOOP2_VERSION=2.6.0-cdh5.15.0
+ENV HADOOP3_VERSION=3.1.2
 ENV SPARK_VERSION=2.4.1
 ENV FLINK_VERSION=1.6.4
 
 # Environment Config
+ENV HADOOP2_CONF_DIR=/opt/hadoop2/etc/hadoop
+ENV HADOOP3_CONF_DIR=/opt/hadoop3/etc/hadoop
 ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop
 ENV YARN_CONF_DIR=${HADOOP_CONF_DIR}
 ENV SPARK_CONF_DIR=/opt/spark/conf
 ENV HADOOP_LOG_DIR=/var/log/hadoop
+
+ENV HADOOP_LIBEXEC_DIR=/opt/hadoop/libexec
 
 # Add Epel, tooling and update
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-${EPEL_VERSION}.noarch.rpm && \
@@ -30,11 +35,17 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-${EPEL_VERSION}.
     yum install -y wget tar which net-tools curl tcpdump java-1.8.0-openjdk-devel && \
     yum clean all
 
-# Download and unzip hadoop
-RUN wget http://archive.cloudera.com/cdh5/cdh/5/hadoop-${HADOOP_VERSION}.tar.gz && \
-    tar xvfz hadoop-${HADOOP_VERSION}.tar.gz -C /opt && \
-    ln -s /opt/hadoop-${HADOOP_VERSION} /opt/hadoop && \
-    rm -f hadoop-${HADOOP_VERSION}.tar.gz
+# Download and unzip hadoop 2
+RUN wget http://archive.cloudera.com/cdh5/cdh/5/hadoop-${HADOOP2_VERSION}.tar.gz && \
+    tar xvfz hadoop-${HADOOP2_VERSION}.tar.gz -C /opt && \
+    ln -s /opt/hadoop-${HADOOP2_VERSION} /opt/hadoop2 && \
+    rm -f hadoop-${HADOOP2_VERSION}.tar.gz
+
+# Download and unzip hadoop 3
+RUN wget http://mirrors.ircam.fr/pub/apache/hadoop/common/hadoop-${HADOOP3_VERSION}/hadoop-${HADOOP3_VERSION}.tar.gz && \
+    tar xvfz hadoop-${HADOOP3_VERSION}.tar.gz -C /opt && \
+    ln -s /opt/hadoop-${HADOOP3_VERSION} /opt/hadoop3 && \
+    rm -f hadoop-${HADOOP3_VERSION}.tar.gz
 
 # Download and unzip spark
 RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.6.tgz && \
@@ -55,7 +66,8 @@ RUN mkdir -p /opt/garmadon/conf-forwarder \
              /data/hdfs /data/yarn ${HADOOP_LOG_DIR}
 
 # Add configurations and entrypoint
-ADD hadoop_conf/ ${HADOOP_CONF_DIR}
+ADD hadoop_conf/ ${HADOOP2_CONF_DIR}
+ADD hadoop_conf/ ${HADOOP3_CONF_DIR}
 ADD spark_conf ${SPARK_CONF_DIR}
 ADD conf-forwarder/ /opt/garmadon/conf-forwarder
 ADD conf-es-reader/ /opt/garmadon/conf-es-reader
@@ -63,7 +75,7 @@ ADD conf-hdfs-reader/ /opt/garmadon/conf-hdfs-reader
 ADD scripts/ /usr/bin
 ADD ressources/ /tmp
 
-RUN chmod a+x /usr/bin/entrypoint.sh /opt/hadoop/etc/hadoop/*.sh && \
+RUN chmod a+x /usr/bin/entrypoint.sh ${HADOOP2_CONF_DIR}/*.sh ${HADOOP3_CONF_DIR}/*.sh && \
     chmod -R 777 /data/hdfs /data/yarn ${HADOOP_LOG_DIR}
 
 # Define default command.

--- a/test/src/main/docker/garmadon/hadoop_conf/yarn-site.xml
+++ b/test/src/main/docker/garmadon/hadoop_conf/yarn-site.xml
@@ -108,4 +108,9 @@
         <value>JAVA_TOOL_OPTIONS=-javaagent:/opt/garmadon/lib/garmadon-agent.jar=com.criteo.hadoop.garmadon.agent.modules.ContainerModule</value>
     </property>
 
+    <property>
+        <name>yarn.nodemanager.vmem-check-enabled</name>
+        <value>false</value>
+    </property>
+
 </configuration>

--- a/test/src/main/docker/garmadon/scripts/entrypoint.sh
+++ b/test/src/main/docker/garmadon/scripts/entrypoint.sh
@@ -71,13 +71,24 @@ function historyserver {
     mapred historyserver
 }
 
-
 function sparkhistoryserver {
     check_resourcemanager_up
     spark-class org.apache.spark.deploy.history.HistoryServer
 }
 
+function init {
+    if [ "${HADOOP_RELEASE}" = "2" ]
+    then
+      HADOOP_VERSION=${HADOOP2_VERSION}
+    else
+      HADOOP_VERSION=${HADOOP3_VERSION}
+    fi
+    ln -s /opt/hadoop${HADOOP_RELEASE} /opt/hadoop
+    ln -s /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-${HADOOP_VERSION}.jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples.jar
+}
+
 ############# MAIN
+init
 case $1 in
     client)
         client


### PR DESCRIPTION
In order to validate that garmadon agent/hdfs reader is working fine with hadoop 3 update the docker compose platform to be able to start the hadoop cluster with hadoop 3