### PR TITLE
[HDFS EXPORTER] Commit pending files when revoking a partition

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/OffsetResetter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/OffsetResetter.java
@@ -41,7 +41,10 @@ public class OffsetResetter<K, V, MESSAGE_KIND> implements ConsumerRebalanceList
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         for (PartitionedWriter<MESSAGE_KIND> writer : writers) {
+            writer.close();
+
             for (TopicPartition partition : partitions) {
+                // Best case scenario, this should be no-op. If closing failed, we'll forget about this partition
                 writer.dropPartition(partition.partition());
                 partitionRevokedConsumer.accept(partition.partition());
             }

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/kafka/OffsetResetterTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/kafka/OffsetResetterTest.java
@@ -93,6 +93,7 @@ public class OffsetResetterTest {
 
         offsetResetter.onPartitionsRevoked(Arrays.asList(new TopicPartition(TOPIC, 1),
                 new TopicPartition(TOPIC, 2)));
+        verify(writer, times(1)).close();
         verify(writer, times(1)).dropPartition(1);
         verify(writer, times(1)).dropPartition(2);
         verify(partitionsRevokedConsumer, times(1)).accept(1);
@@ -109,7 +110,7 @@ public class OffsetResetterTest {
                 Collections.singleton(writer));
 
         offsetResetter.onPartitionsRevoked(Collections.emptyList());
-        verifyZeroInteractions(writer);
+        verify(writer, times(1)).close();
         verifyZeroInteractions(partitionsRevokedConsumer);
     }
 


### PR DESCRIPTION
Instead of dropping them.

From ConsumerRebalanceListener' doc:
"It is guaranteed that all consumer processes will invoke onPartitionsRevoked prior to any
process invoking onPartitionsAssigned. So if offsets or other state is saved in the
onPartitionsRevoked call it is guaranteed to be saved by the time the process taking over
that partition has their onPartitionsAssigned callback called to load the state."

We used to drop because we (actually, I) thought the behavior was the other way around, i.e.
_assigned_ called before _revoked_