### PR TITLE
Add a leading dot to checkpoint files to exclude them from the Parquet table

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
@@ -150,7 +150,7 @@ public class HdfsExporter {
                     Path dayDir = new Path(finalEventDir,
                             delayedPathComputer.apply(instant.atZone(ZoneId.of("UTC"))));
 
-                    return new Path(dayDir, partition.toString() + ".done");
+                    return new Path(dayDir, "." + partition.toString() + ".done");
                 });
 
             consumerBuilder = buildMessageConsumerBuilder(fs, new Path(temporaryHdfsDir, eventName),


### PR DESCRIPTION
Otherwise, it fails with:
java.lang.RuntimeException: .../0.done is not a Parquet file (too small)