### PR TITLE
Add support for key value yarn.tags

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -137,6 +137,12 @@
             <version>${prestosql.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnable.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnable.java
@@ -66,11 +66,11 @@ public class RMContextImplEventRunnable implements Runnable {
                 .setQueue(rmApp.getQueue());
 
             rmApp.getApplicationTags().stream()
-                    .filter(tag -> YARN_TAGS_TO_EXTRACT.stream().noneMatch(tag::startsWith))
+                    .filter(tag -> YARN_TAGS_TO_EXTRACT.stream().noneMatch(tag::startsWith) && !tag.contains(":"))
                     .forEach(eventBuilder::addYarnTags);
 
             rmApp.getApplicationTags().stream()
-                    .filter(tag -> YARN_TAGS_TO_EXTRACT.stream().anyMatch(tag::startsWith))
+                    .filter(tag -> tag.contains(":") && YARN_TAGS_TO_EXTRACT.stream().anyMatch(tag::startsWith))
                     .map(tag -> {
                         int idx = tag.indexOf(':');
                         String key = tag.substring(0, idx);

--- a/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnableTest.java
+++ b/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnableTest.java
@@ -49,7 +49,7 @@ public class RMContextImplEventRunnableTest {
 
         rmAppAttempt = mock(RMAppAttempt.class);
         when(rmApp.getCurrentAppAttempt()).thenReturn(rmAppAttempt);
-        when(rmApp.getApplicationTags()).thenReturn(new HashSet<>(Arrays.asList("simpleTag", "key:value")));
+        when(rmApp.getApplicationTags()).thenReturn(new HashSet<>(Arrays.asList("simpleTag", "garmadon.project.name:project", "garmadon.workflow.name:workflow")));
 
         applicationAttemptId = mock(ApplicationAttemptId.class);
         when(rmAppAttempt.getAppAttemptId()).thenReturn(applicationAttemptId);
@@ -75,6 +75,7 @@ public class RMContextImplEventRunnableTest {
         assertThat(appEvent.getAmContainerId()).isEqualTo("container_id_001");
         assertThat(appEvent.getTrackingUrl()).isEqualTo("");
 
-        assertThat(appEvent.getUserTagsMap()).containsExactly(entry("key", "value"));
+        assertThat(appEvent.getProjectName()).isEqualTo("project");
+        assertThat(appEvent.getWorkflowName()).isEqualTo("workflow");
     }
 }

--- a/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnableTest.java
+++ b/agent/src/test/java/com/criteo/hadoop/garmadon/agent/tracers/hadoop/resourcemanager/RMContextImplEventRunnableTest.java
@@ -14,10 +14,12 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
-
+import static org.assertj.core.api.Assertions.*;
 
 public class RMContextImplEventRunnableTest {
     private RMContextImplEventRunnable rmContextImplEventRunnable;
@@ -47,6 +49,7 @@ public class RMContextImplEventRunnableTest {
 
         rmAppAttempt = mock(RMAppAttempt.class);
         when(rmApp.getCurrentAppAttempt()).thenReturn(rmAppAttempt);
+        when(rmApp.getApplicationTags()).thenReturn(new HashSet<>(Arrays.asList("simpleTag", "key:value")));
 
         applicationAttemptId = mock(ApplicationAttemptId.class);
         when(rmAppAttempt.getAppAttemptId()).thenReturn(applicationAttemptId);
@@ -69,7 +72,9 @@ public class RMContextImplEventRunnableTest {
 
         ResourceManagerEventProtos.ApplicationEvent appEvent = argument.getValue();
 
-        assert ("container_id_001".equals(appEvent.getAmContainerId()));
-        assert ("".equals(appEvent.getTrackingUrl()));
+        assertThat(appEvent.getAmContainerId()).isEqualTo("container_id_001");
+        assertThat(appEvent.getTrackingUrl()).isEqualTo("");
+
+        assertThat(appEvent.getUserTagsMap()).containsExactly(entry("key", "value"));
     }
 }

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/protobuf/ProtoConcatenator.java
@@ -84,7 +84,11 @@ public class ProtoConcatenator {
                 Map<String, Object> concatMap = new HashMap<>(keys.size());
                 if (includeDefaultValueFields) {
                     for (Descriptors.FieldDescriptor fieldDescriptor : keys) {
-                        concatMap.put(fieldDescriptor.getName(), getRealFieldValue(fieldDescriptor.getDefaultValue()));
+                        if (fieldDescriptor.isMapField()) {
+                            concatMap.put(fieldDescriptor.getName(), new HashMap<Object, Object>());
+                        } else {
+                            concatMap.put(fieldDescriptor.getName(), getRealFieldValue(fieldDescriptor.getDefaultValue()));
+                        }
                     }
                 }
                 concatMap.put(TIMESTAMP_FIELD_NAME, timestampMillis);
@@ -203,7 +207,7 @@ public class ProtoConcatenator {
     }
 
     private static Object getRealFieldValue(Object valueObject) {
-        if (valueObject instanceof Descriptors.EnumValueDescriptor) {
+        if (valueObject != null && valueObject instanceof Descriptors.EnumValueDescriptor) {
             return ((Descriptors.EnumValueDescriptor) valueObject).getName();
         } else {
             return valueObject;

--- a/readers/elasticsearch/src/main/resources/template.json
+++ b/readers/elasticsearch/src/main/resources/template.json
@@ -68,14 +68,24 @@
     "project_name": {
       "type": "text",
       "norms": false,
-      "index_options": "freqs",
-      "eager_global_ordinals": true
+      "index_options": "positions",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 1024
+        }
+      }
     },
     "workflow_name": {
       "type": "text",
       "norms": false,
-      "index_options": "freqs",
-      "eager_global_ordinals": true
+      "index_options": "positions",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 1024
+        }
+      }
     },
     "attempt_id": {
       "type": "keyword",

--- a/readers/elasticsearch/src/main/resources/template.json
+++ b/readers/elasticsearch/src/main/resources/template.json
@@ -803,6 +803,9 @@
       "index_options": "freqs",
       "eager_global_ordinals": true
     },
+    "user_tags": {
+      "type": "object"
+    },
     "value": {
       "type": "float",
       "index": false

--- a/readers/elasticsearch/src/main/resources/template.json
+++ b/readers/elasticsearch/src/main/resources/template.json
@@ -65,6 +65,18 @@
         }
       }
     },
+    "project_name": {
+      "type": "text",
+      "norms": false,
+      "index_options": "freqs",
+      "eager_global_ordinals": true
+    },
+    "workflow_name": {
+      "type": "text",
+      "norms": false,
+      "index_options": "freqs",
+      "eager_global_ordinals": true
+    },
     "attempt_id": {
       "type": "keyword",
       "norms": false,
@@ -802,9 +814,6 @@
       "norms": false,
       "index_options": "freqs",
       "eager_global_ordinals": true
-    },
-    "user_tags": {
-      "type": "object"
     },
     "value": {
       "type": "float",

--- a/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
+++ b/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
@@ -121,8 +121,7 @@ public class ElasticSearchReaderTest {
                 .setState(state)
                 .build();
 
-        Map<String, Object> eventMap = new HashMap<>();
-        eventMap.putAll(headerMap);
+        Map<String, Object> eventMap = new HashMap<>(headerMap);
         eventMap.put("event_type", GarmadonSerialization.getTypeName(type));
         eventMap.put("state", state);
         eventMap.put("queue", "dev");
@@ -130,6 +129,7 @@ public class ElasticSearchReaderTest {
         eventMap.put("original_tracking_url", "");
         eventMap.put("am_container_id", "");
         eventMap.put("yarn_tags", new ArrayList<>());
+        eventMap.put("user_tags", new HashMap<>());
 
         writeGarmadonMessage(type, event, 0L);
         verify(bulkProcessor, times(1)).add(argument.capture(), any(CommittableOffset.class));

--- a/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
+++ b/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/ElasticSearchReaderTest.java
@@ -129,7 +129,8 @@ public class ElasticSearchReaderTest {
         eventMap.put("original_tracking_url", "");
         eventMap.put("am_container_id", "");
         eventMap.put("yarn_tags", new ArrayList<>());
-        eventMap.put("user_tags", new HashMap<>());
+        eventMap.put("project_name", "");
+        eventMap.put("workflow_name", "");
 
         writeGarmadonMessage(type, event, 0L);
         verify(bulkProcessor, times(1)).add(argument.capture(), any(CommittableOffset.class));

--- a/schema/src/main/protobuf/resourcemanager_event.proto
+++ b/schema/src/main/protobuf/resourcemanager_event.proto
@@ -12,4 +12,5 @@ message ApplicationEvent {
     string original_tracking_url = 4;
     repeated string yarn_tags = 5;
     string am_container_id = 6;
+    map<string, string> user_tags = 7;
 }

--- a/schema/src/main/protobuf/resourcemanager_event.proto
+++ b/schema/src/main/protobuf/resourcemanager_event.proto
@@ -12,5 +12,6 @@ message ApplicationEvent {
     string original_tracking_url = 4;
     repeated string yarn_tags = 5;
     string am_container_id = 6;
-    map<string, string> user_tags = 7;
+    string project_name = 7;
+    string workflow_name = 8;
 }


### PR DESCRIPTION
It may be interesting to tag via key value applications running on a hadoop cluster.
Unfortunately, yarn.tags (supported by most frameworks) are a list of string.
This change adds the ability to have special yarn.tags containing a ':' to split key and value.

All those tags will appear in the ApplicationEvent under field user_tags which is a map of
string to string.

It will be exported as nested object on ElasticSearch or Parquet.