### PR TITLE
Some of the JVMStats section contains empty property string leading to bad fields beeing added to ES

### DIFF
--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
@@ -31,10 +31,12 @@ class EventHelper {
             } else {
                 Map<String, Object> eventMap = eventMaps.computeIfAbsent(type, s -> EventHelper.initEvent(type));
                 for (JVMStatisticsEventsProtos.JVMStatisticsData.Property property : section.getPropertyList()) {
-                    try {
-                        eventMap.put(section.getName() + "_" + property.getName(), Double.parseDouble(property.getValue()));
-                    } catch (NumberFormatException nfe) {
-                        eventMap.put(section.getName() + "_" + property.getName(), property.getValue());
+                    if (!"".equals(property.getName())) {
+                        try {
+                            eventMap.put(section.getName() + "_" + property.getName(), Double.parseDouble(property.getValue()));
+                        } catch (NumberFormatException nfe) {
+                            eventMap.put(section.getName() + "_" + property.getName(), property.getValue());
+                        }
                     }
                 }
             }

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelper.java
@@ -31,7 +31,7 @@ class EventHelper {
             } else {
                 Map<String, Object> eventMap = eventMaps.computeIfAbsent(type, s -> EventHelper.initEvent(type));
                 for (JVMStatisticsEventsProtos.JVMStatisticsData.Property property : section.getPropertyList()) {
-                    if (!"".equals(property.getName())) {
+                    if (!property.getName().isEmpty()) { // Some section can contains empty property. Not indexing them to avoid adding polluting fields in ES
                         try {
                             eventMap.put(section.getName() + "_" + property.getName(), Double.parseDouble(property.getValue()));
                         } catch (NumberFormatException nfe) {

--- a/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelperTest.java
+++ b/readers/elasticsearch/src/test/java/com/criteo/hadoop/garmadon/elasticsearch/EventHelperTest.java
@@ -16,63 +16,78 @@ public class EventHelperTest {
     public void setUp() {
         eventMaps = new HashMap<>();
     }
+
     @Test
     public void processJVMStatisticsData_should_add_3_hashmap_disk_network_and_jvm() {
         // Disk section
         String disk = "sda";
         JVMStatisticsEventsProtos.JVMStatisticsData.Property propertyDisk = JVMStatisticsEventsProtos.JVMStatisticsData.Property
-                .newBuilder()
-                .setName(disk + "_write")
-                .setValue("10000")
-                .build();
+            .newBuilder()
+            .setName(disk + "_write")
+            .setValue("10000")
+            .build();
         JVMStatisticsEventsProtos.JVMStatisticsData.Section sectionDisk = JVMStatisticsEventsProtos.JVMStatisticsData.Section
-                .newBuilder()
-                .setName("disk")
-                .addProperty(propertyDisk)
-                .build();
+            .newBuilder()
+            .setName("disk")
+            .addProperty(propertyDisk)
+            .build();
 
         // Network Section
         String network = "enp129s0";
         JVMStatisticsEventsProtos.JVMStatisticsData.Property propertyNetwork = JVMStatisticsEventsProtos.JVMStatisticsData.Property
-                .newBuilder()
-                .setName(network + "_rx")
-                .setValue("100000")
-                .build();
+            .newBuilder()
+            .setName(network + "_rx")
+            .setValue("100000")
+            .build();
         JVMStatisticsEventsProtos.JVMStatisticsData.Section sectionNetwork = JVMStatisticsEventsProtos.JVMStatisticsData.Section
-                .newBuilder()
-                .setName("network")
-                .addProperty(propertyNetwork)
-                .build();
+            .newBuilder()
+            .setName("network")
+            .addProperty(propertyNetwork)
+            .build();
 
 
         // Others Section
         JVMStatisticsEventsProtos.JVMStatisticsData.Property propertyOther = JVMStatisticsEventsProtos.JVMStatisticsData.Property
-                .newBuilder()
-                .setName("physical")
-                .setValue("499")
-                .build();
+            .newBuilder()
+            .setName("physical")
+            .setValue("499")
+            .build();
         JVMStatisticsEventsProtos.JVMStatisticsData.Section sectionOther1 = JVMStatisticsEventsProtos.JVMStatisticsData.Section
-                .newBuilder()
-                .setName("memory")
-                .addProperty(propertyOther)
-                .build();
+            .newBuilder()
+            .setName("memory")
+            .addProperty(propertyOther)
+            .build();
         JVMStatisticsEventsProtos.JVMStatisticsData.Section sectionOther2 = JVMStatisticsEventsProtos.JVMStatisticsData.Section
-                .newBuilder()
-                .setName("machinecpu")
-                .addProperty(propertyOther)
-                .build();
+            .newBuilder()
+            .setName("machinecpu")
+            .addProperty(propertyOther)
+            .build();
+
+        // Empty section
+        JVMStatisticsEventsProtos.JVMStatisticsData.Property propertyEmpty = JVMStatisticsEventsProtos.JVMStatisticsData.Property
+            .newBuilder()
+            .setName("")
+            .setValue("")
+            .build();
+        JVMStatisticsEventsProtos.JVMStatisticsData.Section sectionEmpty = JVMStatisticsEventsProtos.JVMStatisticsData.Section
+            .newBuilder()
+            .setName("class")
+            .addProperty(propertyEmpty)
+            .build();
 
         JVMStatisticsEventsProtos.JVMStatisticsData event = JVMStatisticsEventsProtos.JVMStatisticsData
-                .newBuilder()
-                .addSection(sectionDisk)
-                .addSection(sectionNetwork)
-                .addSection(sectionOther1)
-                .addSection(sectionOther2)
-                .build();
+            .newBuilder()
+            .addSection(sectionDisk)
+            .addSection(sectionNetwork)
+            .addSection(sectionOther1)
+            .addSection(sectionOther2)
+            .addSection(sectionEmpty)
+            .build();
         EventHelper.processJVMStatisticsData(GarmadonSerialization.getTypeName(1001), event, eventMaps);
         Assert.assertEquals(disk, eventMaps.get(disk).get("disk"));
         Assert.assertEquals(network, eventMaps.get(network).get("network"));
         Assert.assertEquals(499.0, eventMaps.get(GarmadonSerialization.getTypeName(1001)).get("memory_physical"));
         Assert.assertEquals(499.0, eventMaps.get(GarmadonSerialization.getTypeName(1001)).get("machinecpu_physical"));
+        Assert.assertFalse(eventMaps.get(GarmadonSerialization.getTypeName(1001)).containsKey("class_"));
     }
 }


### PR DESCRIPTION
If property name is empty we are adding fields section_ to the document.
This leads to some fields like code_, class_... to be added and indexed even if they have empty value.
As they are not usefull we shoulkd just skip them if it is empty