### PR TITLE
Enforce usage of trusty distrib as oracle 8 deployment failed on xenial one in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
 - oraclejdk8


### PR DESCRIPTION
See build: https://travis-ci.org/criteo/garmadon/jobs/563918444
And https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/5