### PR TITLE
Remove Safepoints & Locks heuristics from the DrElephant exporter

### DIFF
--- a/readers/heuristics/src/main/java/com/criteo/hadoop/garmadon/heuristics/Heuristics.java
+++ b/readers/heuristics/src/main/java/com/criteo/hadoop/garmadon/heuristics/Heuristics.java
@@ -81,8 +81,6 @@ public class Heuristics {
         jvmStatsHeuristics.add(new HeapUsage(db));
         jvmStatsHeuristics.add(new Threads(db));
         jvmStatsHeuristics.add(new CodeCacheUsage(db));
-        jvmStatsHeuristics.add(new Safepoints(db));
-        jvmStatsHeuristics.add(new Locks(db));
 
         this.heuristics.add(fileHeuristic);
         this.heuristics.addAll(gcStatsHeuristics);


### PR DESCRIPTION
These metrics are always red ATM.
They are too complex for users to understand and for us to finetune, so we decide to ignore them for now.

JIRA: LAKECOMP-1303