### PR TITLE
[HDFS-READER] Implement multithreading by creating multiple instances of Gramadon reader

### DIFF
--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Optional;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -21,59 +22,66 @@ import java.util.concurrent.TimeUnit;
  */
 public class PrometheusHttpConsumerMetrics {
     public static final String RELEASE = Optional
-            .ofNullable(PrometheusHttpConsumerMetrics.class.getPackage().getImplementationVersion())
-            .orElse("1.0-SNAPSHOT")
-            .replace(".", "_");
+        .ofNullable(PrometheusHttpConsumerMetrics.class.getPackage().getImplementationVersion())
+        .orElse("1.0-SNAPSHOT")
+        .replace(".", "_");
 
     public static final Counter GARMADON_READER_METRICS = Counter.build()
-            .name("garmadon_reader_metrics").help("Garmadon reader metrics")
-            .labelNames("name", "hostname", "release")
-            .register();
+        .name("garmadon_reader_metrics").help("Garmadon reader metrics")
+        .labelNames("name", "hostname", "release")
+        .register();
 
     public static final Summary LATENCY_INDEXING_TO_ES = Summary.build()
-            .name("garmadon_reader_duration").help("Duration in ms")
-            .labelNames("name", "hostname", "release")
-            .quantile(0.75, 0.01)
-            .quantile(0.9, 0.01)
-            .quantile(0.99, 0.001)
-            .register();
+        .name("garmadon_reader_duration").help("Duration in ms")
+        .labelNames("name", "hostname", "release")
+        .quantile(0.75, 0.01)
+        .quantile(0.9, 0.01)
+        .quantile(0.99, 0.001)
+        .register();
 
     public static final Counter.Child ISSUE_READING_GARMADON_MESSAGE_BAD_HEAD = PrometheusHttpConsumerMetrics.GARMADON_READER_METRICS
-            .labels("issue_reading_garmadon_message_bad_head",
-                    GarmadonReader.getHostname(),
-                    PrometheusHttpConsumerMetrics.RELEASE);
+        .labels("issue_reading_garmadon_message_bad_head",
+            GarmadonReader.getHostname(),
+            PrometheusHttpConsumerMetrics.RELEASE);
 
     public static final Gauge GARMADON_READER_LAST_EVENT_TIMESTAMP = Gauge.build()
-            .name("garmadon_reader_last_event_timestamp").help("Garmadon reader last event timestamp")
-            .labelNames("name", "hostname", "release", "partition")
-            .register();
+        .name("garmadon_reader_last_event_timestamp").help("Garmadon reader last event timestamp")
+        .labelNames("name", "hostname", "release", "partition")
+        .register();
 
     public static final Counter.Child ISSUE_READING_PROTO_HEAD = PrometheusHttpConsumerMetrics.GARMADON_READER_METRICS.labels("issue_reading_proto_head",
-            GarmadonReader.getHostname(),
-            PrometheusHttpConsumerMetrics.RELEASE);
+        GarmadonReader.getHostname(),
+        PrometheusHttpConsumerMetrics.RELEASE);
 
     public static final Counter.Child ISSUE_READING_PROTO_BODY = PrometheusHttpConsumerMetrics.GARMADON_READER_METRICS.labels("issue_reading_proto_body",
-            GarmadonReader.getHostname(),
-            PrometheusHttpConsumerMetrics.RELEASE);
+        GarmadonReader.getHostname(),
+        PrometheusHttpConsumerMetrics.RELEASE);
 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PrometheusHttpConsumerMetrics.class);
     private static final MBeanServer MBS = ManagementFactory.getPlatformMBeanServer();
 
     private static final Gauge BASE_KAFKA_METRICS_GAUGE = Gauge.build()
-            .name("garmadon_kafka_metrics").help("Kafka producer metrics")
-            .labelNames("name", "hostname", "release")
-            .register();
+        .name("garmadon_kafka_metrics").help("Kafka producer metrics")
+        .labelNames("name", "hostname", "release")
+        .register();
 
-    private static ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1);
+    private static ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "prometheus-refresh-jmx-kafka-metrics");
+            t.setDaemon(true);
+            return t;
+        }
+    });
 
-    private static ObjectName oName;
+    private static ObjectName baseKafkaJmxName;
 
     static {
         // Expose JMX, GCs, classloading, thread count, memory pool
         DefaultExports.initialize();
         try {
-            oName = new ObjectName("kafka.consumer:type=consumer-metrics,client-id=" + GarmadonReader.CONSUMER_ID);
+            baseKafkaJmxName = new ObjectName("kafka.consumer:type=consumer-metrics,client-id=consumer-*");
         } catch (MalformedObjectNameException e) {
             LOGGER.error("", e);
         }
@@ -102,13 +110,15 @@ public class PrometheusHttpConsumerMetrics {
 
     protected static void exposeKafkaMetrics() {
         try {
-            if (oName != null) {
-                MBeanInfo info = MBS.getMBeanInfo(oName);
-                MBeanAttributeInfo[] attrInfo = info.getAttributes();
-                for (MBeanAttributeInfo attr : attrInfo) {
-                    if (attr.isReadable() && attr.getType().equals("double")) {
-                        BASE_KAFKA_METRICS_GAUGE.labels(attr.getName(), GarmadonReader.getHostname(), RELEASE)
-                                .set((Double) MBS.getAttribute(oName, attr.getName()));
+            if (baseKafkaJmxName != null) {
+                for (ObjectName name : MBS.queryNames(baseKafkaJmxName, null)) {
+                    MBeanInfo info = MBS.getMBeanInfo(name);
+                    MBeanAttributeInfo[] attrInfo = info.getAttributes();
+                    for (MBeanAttributeInfo attr : attrInfo) {
+                        if (attr.isReadable() && attr.getType().equals("double")) {
+                            BASE_KAFKA_METRICS_GAUGE.labels(attr.getName(), GarmadonReader.getHostname(), RELEASE)
+                                .set((Double) MBS.getAttribute(name, attr.getName()));
+                        }
                     }
                 }
             }

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetrics.java
@@ -63,7 +63,7 @@ public class PrometheusHttpConsumerMetrics {
 
     private static final Gauge BASE_KAFKA_METRICS_GAUGE = Gauge.build()
         .name("garmadon_kafka_metrics").help("Kafka producer metrics")
-        .labelNames("name", "hostname", "release")
+        .labelNames("name", "hostname", "release", "consumer_id")
         .register();
 
     private static ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactory() {
@@ -81,7 +81,7 @@ public class PrometheusHttpConsumerMetrics {
         // Expose JMX, GCs, classloading, thread count, memory pool
         DefaultExports.initialize();
         try {
-            baseKafkaJmxName = new ObjectName("kafka.consumer:type=consumer-metrics,client-id=consumer-*");
+            baseKafkaJmxName = new ObjectName("kafka.consumer:type=consumer-metrics,client-id=*");
         } catch (MalformedObjectNameException e) {
             LOGGER.error("", e);
         }
@@ -116,7 +116,7 @@ public class PrometheusHttpConsumerMetrics {
                     MBeanAttributeInfo[] attrInfo = info.getAttributes();
                     for (MBeanAttributeInfo attr : attrInfo) {
                         if (attr.isReadable() && attr.getType().equals("double")) {
-                            BASE_KAFKA_METRICS_GAUGE.labels(attr.getName(), GarmadonReader.getHostname(), RELEASE)
+                            BASE_KAFKA_METRICS_GAUGE.labels(attr.getName(), GarmadonReader.getHostname(), RELEASE, name.getKeyProperty("client-id"))
                                 .set((Double) MBS.getAttribute(name, attr.getName()));
                         }
                     }

--- a/readers/common/src/test/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetricsTest.java
+++ b/readers/common/src/test/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetricsTest.java
@@ -21,7 +21,7 @@ public class PrometheusHttpConsumerMetricsTest {
 
     @Before
     public void up() throws MalformedObjectNameException, NotCompliantMBeanException, InstanceAlreadyExistsException, MBeanRegistrationException {
-        String objectName = "kafka.consumer:type=consumer-metrics,client-id=" + GarmadonReader.CONSUMER_ID;
+        String objectName = "kafka.consumer:type=consumer-metrics,client-id=consumer-1";
 
         mbeanName = new ObjectName(objectName);
         KafkaMetrics mbean = new KafkaMetrics();

--- a/readers/common/src/test/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetricsTest.java
+++ b/readers/common/src/test/java/com/criteo/hadoop/garmadon/reader/metrics/PrometheusHttpConsumerMetricsTest.java
@@ -49,8 +49,8 @@ public class PrometheusHttpConsumerMetricsTest {
     public void Prometheus_Collect_Kafka_metrics() throws MBeanException, IntrospectionException, ReflectionException, AttributeNotFoundException, InstanceNotFoundException {
         PrometheusHttpConsumerMetrics.exposeKafkaMetrics();
         assertNotNull(CollectorRegistry.defaultRegistry.getSampleValue("garmadon_kafka_metrics",
-                new String[]{"name", "hostname", "release"},
-                new String[]{"IoStats", GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE}));
+                new String[]{"name", "hostname", "release", "consumer_id"},
+                new String[]{"IoStats", GarmadonReader.getHostname(), PrometheusHttpConsumerMetrics.RELEASE, "consumer-1"}));
     }
 
     static class KafkaMetrics implements KafkaMetricsMBean {

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/HdfsExporter.java
@@ -1,45 +1,29 @@
 package com.criteo.hadoop.garmadon.hdfs;
 
-import com.criteo.hadoop.garmadon.event.proto.*;
-import com.criteo.hadoop.garmadon.hdfs.configurations.HdfsConfiguration;
 import com.criteo.hadoop.garmadon.hdfs.configurations.HdfsReaderConfiguration;
-import com.criteo.hadoop.garmadon.hdfs.kafka.OffsetResetter;
-import com.criteo.hadoop.garmadon.hdfs.kafka.PartitionsPauseStateHandler;
-import com.criteo.hadoop.garmadon.hdfs.monitoring.PrometheusMetrics;
-import com.criteo.hadoop.garmadon.hdfs.offset.*;
-import com.criteo.hadoop.garmadon.hdfs.writer.*;
-import com.criteo.hadoop.garmadon.reader.CommittableOffset;
+import com.criteo.hadoop.garmadon.hdfs.writer.FileSystemUtils;
 import com.criteo.hadoop.garmadon.reader.GarmadonReader;
 import com.criteo.hadoop.garmadon.reader.configurations.ReaderConfiguration;
 import com.criteo.hadoop.garmadon.reader.metrics.PrometheusHttpConsumerMetrics;
-import com.criteo.hadoop.garmadon.schema.serialization.GarmadonSerialization;
-import com.google.protobuf.Message;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.apache.parquet.proto.ProtoParquetWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.FileSystemNotFoundException;
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import static com.criteo.hadoop.garmadon.reader.GarmadonMessageFilters.any;
-import static com.criteo.hadoop.garmadon.reader.GarmadonMessageFilters.hasType;
 import static java.lang.System.exit;
 
 /**
@@ -57,14 +41,6 @@ public class HdfsExporter {
         System.setProperty("java.util.logging.config.file", path);
     }
 
-    private static int maxTmpFileOpenRetries;
-    private static int messagesBeforeExpiringWriters;
-    private static Duration writersExpirationDelay;
-    private static Duration expirerPeriod;
-    private static Duration heartbeatPeriod;
-    private static Duration tmpFileOpenRetryPeriod;
-    private static int sizeBeforeFlushingTmp;
-
     protected HdfsExporter() {
         throw new UnsupportedOperationException();
     }
@@ -80,269 +56,97 @@ public class HdfsExporter {
     public static void main(String[] args) throws IOException {
         HdfsReaderConfiguration config = ReaderConfiguration.loadConfig(HdfsReaderConfiguration.class);
 
-        setupProperties(config.getHdfs());
-
-        final String baseTemporaryHdfsDir = config.getHdfs().getBaseTemporaryDir();
-        Path finalHdfsDir = new Path(config.getHdfs().getFinalDir());
+        final PrometheusHttpConsumerMetrics prometheusServer = new PrometheusHttpConsumerMetrics(config.getPrometheus().getPort());
 
         FileSystem fs = null;
         try {
-            // Required if using ViewFs to resolve hdfs path and use DistributedFileSystem
-            FileSystem fsTmp = finalHdfsDir.getFileSystem(HDFS_CONF);
-            fsTmp.mkdirs(finalHdfsDir); // Create final folder if not exist before to resolve path
-            finalHdfsDir = fsTmp.resolvePath(finalHdfsDir);
-            fs = finalHdfsDir.getFileSystem(HDFS_CONF);
-        } catch (IOException e) {
-            LOGGER.error("Could not initialize HDFS", e);
-            exit(1);
+            final String baseTemporaryHdfsDir = config.getHdfs().getBaseTemporaryDir();
+            Path finalHdfsDir = new Path(config.getHdfs().getFinalDir());
+
+            try {
+                // Required if using ViewFs to resolve hdfs path and use DistributedFileSystem
+                FileSystem fsTmp = finalHdfsDir.getFileSystem(HDFS_CONF);
+                fsTmp.mkdirs(finalHdfsDir); // Create final folder if not exist before to resolve path
+                finalHdfsDir = fsTmp.resolvePath(finalHdfsDir);
+                fs = finalHdfsDir.getFileSystem(HDFS_CONF);
+            } catch (IOException e) {
+                LOGGER.error("Could not initialize HDFS", e);
+                throw e;
+            }
+
+            if (!(fs instanceof DistributedFileSystem || fs instanceof LocalFileSystem)) {
+                throw new UnsupportedOperationException("Filesystem of type " + fs.getScheme() + " is not supported. Only hdfs and file ones are supported");
+            }
+
+            try {
+                FileSystemUtils.ensureDirectoriesExist(Collections.singletonList(finalHdfsDir), fs);
+            } catch (IOException e) {
+                LOGGER.error("Couldn't ensure base directories exist, exiting", e);
+                throw e;
+            }
+
+            LOGGER.info("Final HDFS dir: {}", finalHdfsDir.toUri());
+
+            ReaderFactory readerFactory = new ReaderFactory(config);
+
+            Path finalHdfsDirCapture = finalHdfsDir;
+            FileSystem fsCapture = fs;
+            List<GarmadonReader> readers = IntStream.range(0, Integer.max(1, config.getParallelism())).mapToObj(i -> {
+                Path temporaryHdfsDir = new Path(baseTemporaryHdfsDir, UUID.randomUUID().toString());
+                try {
+                    FileSystemUtils.ensureDirectoriesExist(Collections.singletonList(temporaryHdfsDir), fsCapture);
+                } catch (IOException e) {
+                    LOGGER.error("Couldn't ensure base directories exist, exiting", e);
+                    exit(1);
+                }
+
+                try {
+                    fsCapture.deleteOnExit(temporaryHdfsDir);
+                } catch (IOException e) {
+                    exit(1);
+                }
+
+                LOGGER.info("Temporary HDFS dir: {}", temporaryHdfsDir.toUri());
+
+                final KafkaConsumer<String, byte[]> kafkaConsumer = kafkaConsumer(config);
+
+                return readerFactory.create(kafkaConsumer, fsCapture, finalHdfsDirCapture, temporaryHdfsDir);
+            }).collect(Collectors.toList());
+
+            CompletableFuture<Object> oneReaderEnds = CompletableFuture.anyOf(
+                readers.stream().map(GarmadonReader::startReading).toArray(CompletableFuture[]::new)
+            )
+                .exceptionally(t -> null);
+
+            CompletableFuture<Void> theEnd = oneReaderEnds.thenCompose(ignored -> {
+                return CompletableFuture.allOf(readers.stream().map(GarmadonReader::stopReading).toArray(CompletableFuture[]::new));
+            });
+
+            try {
+                theEnd.join();
+            } catch (Exception e) {
+                LOGGER.error("Reader thread interrupted", e);
+            }
+
+        } finally {
+            if (fs != null) fs.close();
+            prometheusServer.terminate();
         }
 
-        if (!(fs instanceof DistributedFileSystem || fs instanceof LocalFileSystem)) {
-            throw new UnsupportedOperationException("Filesystem of type " + fs.getScheme() + " is not supported. Only hdfs and file ones are supported");
-        }
+    }
 
+    public static KafkaConsumer<String, byte[]> kafkaConsumer(HdfsReaderConfiguration conf) {
         final Properties props = new Properties();
 
         props.putAll(GarmadonReader.Builder.DEFAULT_KAFKA_PROPS);
 
-        props.putAll(config.getKafka().getSettings());
+        props.putAll(conf.getKafka().getSettings());
 
         // Auto-commit for lag monitoring, since we don't use Kafka commits
         props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         props.setProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "5000");
 
-        final KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(props);
-        final GarmadonReader.Builder readerBuilder = GarmadonReader.Builder.stream(kafkaConsumer);
-        final Collection<PartitionedWriter<Message>> writers = new ArrayList<>();
-        final PartitionedWriter.Expirer expirer = new PartitionedWriter.Expirer<>(writers, expirerPeriod);
-        final HeartbeatConsumer heartbeat = new HeartbeatConsumer<>(writers, heartbeatPeriod);
-        final Map<Integer, GarmadonEventDescriptor> typeToDirAndClass = getTypeToEventDescriptor();
-        final Path temporaryHdfsDir = new Path(baseTemporaryHdfsDir, UUID.randomUUID().toString());
-        final PrometheusHttpConsumerMetrics prometheusServer = new PrometheusHttpConsumerMetrics(config.getPrometheus().getPort());
-
-        try {
-            FileSystemUtils.ensureDirectoriesExist(Arrays.asList(temporaryHdfsDir, finalHdfsDir), fs);
-        } catch (IOException e) {
-            LOGGER.error("Couldn't ensure base directories exist, exiting", e);
-            return;
-        }
-        fs.deleteOnExit(temporaryHdfsDir);
-
-        LOGGER.info("Temporary HDFS dir: {}", temporaryHdfsDir.toUri());
-        LOGGER.info("Final HDFS dir: {}", finalHdfsDir.toUri());
-
-        final PartitionsPauseStateHandler pauser = new PartitionsPauseStateHandler(kafkaConsumer);
-
-        for (Map.Entry<Integer, GarmadonEventDescriptor> out : typeToDirAndClass.entrySet()) {
-            final Integer eventType = out.getKey();
-            final String eventName = out.getValue().getPath();
-            final Class<? extends Message> clazz = out.getValue().getClazz();
-            final Message.Builder emptyMessageBuilder = out.getValue().getEmptyMessageBuilder();
-            final Function<LocalDateTime, ExpiringConsumer<Message>> consumerBuilder;
-            final Path finalEventDir = new Path(finalHdfsDir, eventName);
-            final OffsetComputer offsetComputer = new HdfsOffsetComputer(fs, finalEventDir,
-                config.getKafka().getCluster(), config.getHdfs().getBacklogDays());
-
-            // When it's day D + 2h, checkpoint for day D - 1m
-            final DelayedDailyPathComputer delayedPathComputer = new DelayedDailyPathComputer(Duration.ofHours(24 + 2));
-            final Checkpointer checkpointer = new FsBasedCheckpointer(fs,
-                (partition, instant) -> {
-                    Path dayDir = new Path(finalEventDir,
-                            delayedPathComputer.apply(instant.atZone(ZoneId.of("UTC"))));
-
-                    return new Path(dayDir, "." + partition.toString() + ".done");
-                });
-
-            consumerBuilder = buildMessageConsumerBuilder(fs, new Path(temporaryHdfsDir, eventName),
-                finalEventDir, clazz, offsetComputer, pauser, eventName);
-
-            final PartitionedWriter<Message> writer = new PartitionedWriter<>(
-                consumerBuilder, offsetComputer, eventName, emptyMessageBuilder, checkpointer);
-
-            readerBuilder.intercept(hasType(eventType), buildGarmadonMessageHandler(writer, eventName));
-
-            writers.add(writer);
-        }
-
-        final List<ConsumerRebalanceListener> listeners = Arrays.asList(
-            new OffsetResetter<>(kafkaConsumer, heartbeat::dropPartition, writers), pauser);
-
-        // We need to build a meta listener as only the last call to #subscribe wins
-        kafkaConsumer.subscribe(Collections.singleton(GarmadonReader.GARMADON_TOPIC),
-            new ConsumerRebalanceListener() {
-                @Override
-                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-                    listeners.forEach(listener -> listener.onPartitionsRevoked(partitions));
-                }
-
-                @Override
-                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-                    listeners.forEach(listener -> listener.onPartitionsAssigned(partitions));
-                }
-            });
-
-        readerBuilder.intercept(any(), msg -> {
-            heartbeat.handle(msg);
-
-            CommittableOffset offset = msg.getCommittableOffset();
-
-            Gauge.Child gauge = PrometheusMetrics.buildGaugeChild(PrometheusMetrics.CURRENT_RUNNING_OFFSETS,
-                "global", offset.getPartition());
-            gauge.set(offset.getOffset());
-        });
-
-        final GarmadonReader garmadonReader = readerBuilder.build(false);
-
-        CompletableFuture<Void> readerFuture = garmadonReader.startReading();
-        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = (thread, e) -> {
-            LOGGER.error("Interrupting reader", e);
-            garmadonReader.stopReading();
-        };
-
-        expirer.start(uncaughtExceptionHandler);
-        heartbeat.start(uncaughtExceptionHandler);
-
-        try {
-            readerFuture.join();
-        } catch (Exception e) {
-            LOGGER.error("Reader thread interrupted", e);
-        }
-
-        prometheusServer.terminate();
-        expirer.stop().join();
-        heartbeat.stop().join();
+        return new KafkaConsumer<>(props);
     }
 
-    private static void setupProperties(HdfsConfiguration hdfsConfig) {
-        maxTmpFileOpenRetries = hdfsConfig.getMaxTmpFileOpenRetries();
-        messagesBeforeExpiringWriters = hdfsConfig.getMessagesBeforeExpiringWriters();
-        writersExpirationDelay = Duration.ofMinutes(hdfsConfig.getWritersExpirationDelay());
-        expirerPeriod = Duration.ofSeconds(hdfsConfig.getExpirerPeriod());
-        heartbeatPeriod = Duration.ofSeconds(hdfsConfig.getHeartbeatPeriod());
-        tmpFileOpenRetryPeriod = Duration.ofSeconds(hdfsConfig.getTmpFileOpenRetryPeriod());
-        sizeBeforeFlushingTmp = hdfsConfig.getSizeBeforeFlushingTmp();
-    }
-
-
-    private static Function<LocalDateTime, ExpiringConsumer<Message>> buildMessageConsumerBuilder(
-        FileSystem fs, Path temporaryHdfsDir, Path finalHdfsDir, Class<? extends Message> clazz,
-        OffsetComputer offsetComputer, PartitionsPauseStateHandler partitionsPauser, String eventName) {
-        Counter.Child tmpFileOpenFailures = PrometheusMetrics.buildCounterChild(
-            PrometheusMetrics.TMP_FILE_OPEN_FAILURES, eventName);
-        Counter.Child tmpFilesOpened = PrometheusMetrics.buildCounterChild(
-            PrometheusMetrics.TMP_FILES_OPENED, eventName);
-
-        return dayStartTime -> {
-            final String uniqueFileName = UUID.randomUUID().toString();
-            final String additionalInfo = String.format("Date = %s, Event type = %s", dayStartTime,
-                clazz.getSimpleName());
-
-            for (int i = 0; i < maxTmpFileOpenRetries; ++i) {
-                final Path tmpFilePath = new Path(temporaryHdfsDir, uniqueFileName);
-                final ProtoParquetWriter<Message> protoWriter;
-
-                try {
-                    protoWriter = new ProtoParquetWriter<>(tmpFilePath, clazz, CompressionCodecName.GZIP,
-                        sizeBeforeFlushingTmp * 1_024 * 1_024, 1_024 * 1_024);
-                    tmpFilesOpened.inc();
-                } catch (IOException e) {
-                    LOGGER.warn("Could not initialize writer ({})", additionalInfo, e);
-                    tmpFileOpenFailures.inc();
-
-                    try {
-                        partitionsPauser.pause(clazz);
-                        Thread.sleep(tmpFileOpenRetryPeriod.get(ChronoUnit.SECONDS));
-                    } catch (InterruptedException interrupt) {
-                        LOGGER.info("Interrupted between temp file opening retries", interrupt);
-                    }
-
-                    continue;
-                }
-
-                partitionsPauser.resume(clazz);
-
-                return new ExpiringConsumer<>(new ProtoParquetWriterWithOffset<>(
-                    protoWriter, tmpFilePath, finalHdfsDir, fs, offsetComputer, dayStartTime, eventName),
-                    writersExpirationDelay, messagesBeforeExpiringWriters);
-            }
-
-            // There's definitely something wrong, potentially the whole instance, so stop trying
-            throw new FileSystemNotFoundException(String.format(
-                "Failed opening a temporary file after %d retries: %s",
-                maxTmpFileOpenRetries, additionalInfo));
-        };
-    }
-
-    private static GarmadonReader.GarmadonMessageHandler buildGarmadonMessageHandler(PartitionedWriter<Message> writer,
-                                                                                     String eventName) {
-        return msg -> {
-            final CommittableOffset offset = msg.getCommittableOffset();
-            final Counter.Child messagesWritingFailures = PrometheusMetrics.buildCounterChild(
-                PrometheusMetrics.MESSAGES_WRITING_FAILURES, eventName, offset.getPartition());
-            final Counter.Child messagesWritten = PrometheusMetrics.buildCounterChild(
-                PrometheusMetrics.MESSAGES_WRITTEN, eventName, offset.getPartition());
-
-            Gauge.Child gauge = PrometheusMetrics.buildGaugeChild(PrometheusMetrics.CURRENT_RUNNING_OFFSETS,
-                eventName, offset.getPartition());
-            gauge.set(offset.getOffset());
-
-            try {
-                writer.write(Instant.ofEpochMilli(msg.getTimestamp()), offset, msg.toProto());
-
-                messagesWritten.inc();
-            } catch (IOException e) {
-                // We accept losing messages every now and then, but still log failures
-                messagesWritingFailures.inc();
-                LOGGER.warn("Couldn't write a message", e);
-            }
-        };
-    }
-
-    private static Map<Integer, GarmadonEventDescriptor> getTypeToEventDescriptor() {
-        final Map<Integer, GarmadonEventDescriptor> out = new HashMap<>();
-
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FS_EVENT, "fs", EventsWithHeader.FsEvent.class,
-            DataAccessEventProtos.FsEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.GC_EVENT, "gc", EventsWithHeader.GCStatisticsData.class,
-            JVMStatisticsEventsProtos.GCStatisticsData.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.CONTAINER_MONITORING_EVENT, "container",
-            EventsWithHeader.ContainerResourceEvent.class, ContainerEventProtos.ContainerResourceEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_STAGE_EVENT, "spark_stage",
-            EventsWithHeader.SparkStageEvent.class, SparkEventProtos.StageEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_STAGE_STATE_EVENT, "spark_stage_state",
-            EventsWithHeader.SparkStageStateEvent.class, SparkEventProtos.StageStateEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_EXECUTOR_STATE_EVENT, "spark_executor",
-            EventsWithHeader.SparkExecutorStateEvent.class, SparkEventProtos.ExecutorStateEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_TASK_EVENT, "spark_task",
-            EventsWithHeader.SparkTaskEvent.class, SparkEventProtos.TaskEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_RDD_STORAGE_STATUS_EVENT, "spark_rdd_storage_status",
-            EventsWithHeader.SparkRddStorageStatus.class, SparkEventProtos.RDDStorageStatus.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_EXECUTOR_STORAGE_STATUS_EVENT, "spark_executor_storage_status",
-            EventsWithHeader.SparkExecutorStorageStatus.class, SparkEventProtos.ExecutorStorageStatus.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.APPLICATION_EVENT, "application_event",
-            EventsWithHeader.ApplicationEvent.class, ResourceManagerEventProtos.ApplicationEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.CONTAINER_EVENT, "container_event",
-            EventsWithHeader.ContainerEvent.class, ResourceManagerEventProtos.ContainerEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_JOB_MANAGER_EVENT, "flink_job_manager",
-            EventsWithHeader.FlinkJobManagerEvent.class, FlinkEventProtos.JobManagerEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_JOB_EVENT, "flink_job",
-            EventsWithHeader.FlinkJobEvent.class, FlinkEventProtos.JobEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_TASK_MANAGER_EVENT, "flink_task_manager",
-            EventsWithHeader.FlinkTaskManagerEvent.class, FlinkEventProtos.TaskManagerEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_TASK_EVENT, "flink_task",
-            EventsWithHeader.FlinkTaskEvent.class, FlinkEventProtos.TaskEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_OPERATOR_EVENT, "flink_operator",
-            EventsWithHeader.FlinkOperatorEvent.class, FlinkEventProtos.OperatorEvent.newBuilder());
-        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_KAFKA_CONSUMER_EVENT, "flink_kafka_consumer",
-            EventsWithHeader.FlinkKafkaConsumerEvent.class, FlinkEventProtos.KafkaConsumerEvent.newBuilder());
-
-        // TODO: handle JVM events
-
-        return out;
-    }
-
-    private static void addTypeMapping(Map<Integer, GarmadonEventDescriptor> out,
-                                       Integer type, String path, Class<? extends Message> clazz, Message.Builder emptyMessageBuilder) {
-        out.put(type, new GarmadonEventDescriptor(path, clazz, emptyMessageBuilder));
-    }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -1,0 +1,276 @@
+package com.criteo.hadoop.garmadon.hdfs;
+
+import com.criteo.hadoop.garmadon.event.proto.*;
+import com.criteo.hadoop.garmadon.hdfs.configurations.HdfsReaderConfiguration;
+import com.criteo.hadoop.garmadon.hdfs.kafka.OffsetResetter;
+import com.criteo.hadoop.garmadon.hdfs.kafka.PartitionsPauseStateHandler;
+import com.criteo.hadoop.garmadon.hdfs.monitoring.PrometheusMetrics;
+import com.criteo.hadoop.garmadon.hdfs.offset.*;
+import com.criteo.hadoop.garmadon.hdfs.writer.DelayedDailyPathComputer;
+import com.criteo.hadoop.garmadon.hdfs.writer.ExpiringConsumer;
+import com.criteo.hadoop.garmadon.hdfs.writer.PartitionedWriter;
+import com.criteo.hadoop.garmadon.hdfs.writer.ProtoParquetWriterWithOffset;
+import com.criteo.hadoop.garmadon.reader.CommittableOffset;
+import com.criteo.hadoop.garmadon.reader.GarmadonReader;
+import com.criteo.hadoop.garmadon.schema.serialization.GarmadonSerialization;
+import com.google.protobuf.Message;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.proto.ProtoParquetWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystemNotFoundException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static com.criteo.hadoop.garmadon.reader.GarmadonMessageFilters.any;
+import static com.criteo.hadoop.garmadon.reader.GarmadonMessageFilters.hasType;
+
+public class ReaderFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReaderFactory.class);
+
+    private static final AtomicInteger READER_IDX = new AtomicInteger(0);
+
+    private static Map<Integer, GarmadonEventDescriptor> typeToEventDescriptor;
+
+    {
+        Map<Integer, GarmadonEventDescriptor> out = new HashMap<>();
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FS_EVENT, "fs", EventsWithHeader.FsEvent.class,
+            DataAccessEventProtos.FsEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.GC_EVENT, "gc", EventsWithHeader.GCStatisticsData.class,
+            JVMStatisticsEventsProtos.GCStatisticsData.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.CONTAINER_MONITORING_EVENT, "container",
+            EventsWithHeader.ContainerResourceEvent.class, ContainerEventProtos.ContainerResourceEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_STAGE_EVENT, "spark_stage",
+            EventsWithHeader.SparkStageEvent.class, SparkEventProtos.StageEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_STAGE_STATE_EVENT, "spark_stage_state",
+            EventsWithHeader.SparkStageStateEvent.class, SparkEventProtos.StageStateEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_EXECUTOR_STATE_EVENT, "spark_executor",
+            EventsWithHeader.SparkExecutorStateEvent.class, SparkEventProtos.ExecutorStateEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_TASK_EVENT, "spark_task",
+            EventsWithHeader.SparkTaskEvent.class, SparkEventProtos.TaskEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_RDD_STORAGE_STATUS_EVENT, "spark_rdd_storage_status",
+            EventsWithHeader.SparkRddStorageStatus.class, SparkEventProtos.RDDStorageStatus.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.SPARK_EXECUTOR_STORAGE_STATUS_EVENT, "spark_executor_storage_status",
+            EventsWithHeader.SparkExecutorStorageStatus.class, SparkEventProtos.ExecutorStorageStatus.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.APPLICATION_EVENT, "application_event",
+            EventsWithHeader.ApplicationEvent.class, ResourceManagerEventProtos.ApplicationEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.CONTAINER_EVENT, "container_event",
+            EventsWithHeader.ContainerEvent.class, ResourceManagerEventProtos.ContainerEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_JOB_MANAGER_EVENT, "flink_job_manager",
+            EventsWithHeader.FlinkJobManagerEvent.class, FlinkEventProtos.JobManagerEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_JOB_EVENT, "flink_job",
+            EventsWithHeader.FlinkJobEvent.class, FlinkEventProtos.JobEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_TASK_MANAGER_EVENT, "flink_task_manager",
+            EventsWithHeader.FlinkTaskManagerEvent.class, FlinkEventProtos.TaskManagerEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_TASK_EVENT, "flink_task",
+            EventsWithHeader.FlinkTaskEvent.class, FlinkEventProtos.TaskEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_OPERATOR_EVENT, "flink_operator",
+            EventsWithHeader.FlinkOperatorEvent.class, FlinkEventProtos.OperatorEvent.newBuilder());
+        addTypeMapping(out, GarmadonSerialization.TypeMarker.FLINK_KAFKA_CONSUMER_EVENT, "flink_kafka_consumer",
+            EventsWithHeader.FlinkKafkaConsumerEvent.class, FlinkEventProtos.KafkaConsumerEvent.newBuilder());
+        typeToEventDescriptor = Collections.unmodifiableMap(out);
+    }
+
+    private final int maxTmpFileOpenRetries;
+    private final int messagesBeforeExpiringWriters;
+    private final Duration writersExpirationDelay;
+    private final Duration expirerPeriod;
+    private final Duration heartbeatPeriod;
+    private final Duration tmpFileOpenRetryPeriod;
+    private final int sizeBeforeFlushingTmp;
+    private final int backlogDays;
+    private final String kafkaCluster;
+
+    public ReaderFactory(HdfsReaderConfiguration conf) {
+        maxTmpFileOpenRetries = conf.getHdfs().getMaxTmpFileOpenRetries();
+        messagesBeforeExpiringWriters = conf.getHdfs().getMessagesBeforeExpiringWriters();
+        writersExpirationDelay = Duration.ofMinutes(conf.getHdfs().getWritersExpirationDelay());
+        expirerPeriod = Duration.ofSeconds(conf.getHdfs().getExpirerPeriod());
+        heartbeatPeriod = Duration.ofSeconds(conf.getHdfs().getHeartbeatPeriod());
+        tmpFileOpenRetryPeriod = Duration.ofSeconds(conf.getHdfs().getTmpFileOpenRetryPeriod());
+        sizeBeforeFlushingTmp = conf.getHdfs().getSizeBeforeFlushingTmp();
+        backlogDays = conf.getHdfs().getBacklogDays();
+        kafkaCluster = conf.getKafka().getCluster();
+    }
+
+    private static void addTypeMapping(Map<Integer, GarmadonEventDescriptor> out,
+                                       Integer type, String path, Class<? extends Message> clazz, Message.Builder emptyMessageBuilder) {
+        out.put(type, new GarmadonEventDescriptor(path, clazz, emptyMessageBuilder));
+    }
+
+    public GarmadonReader create(KafkaConsumer<String, byte[]> kafkaConsumer, FileSystem fs, Path finalHdfsDir, Path temporaryHdfsDir) {
+
+        int idx = READER_IDX.getAndIncrement();
+
+        final GarmadonReader.Builder readerBuilder = GarmadonReader.Builder.stream(kafkaConsumer);
+        final Collection<PartitionedWriter<Message>> writers = new ArrayList<>();
+        final PartitionedWriter.Expirer expirer = new PartitionedWriter.Expirer<>(writers, expirerPeriod);
+        final HeartbeatConsumer heartbeat = new HeartbeatConsumer<>(writers, heartbeatPeriod);
+        final PartitionsPauseStateHandler pauser = new PartitionsPauseStateHandler(kafkaConsumer);
+
+        for (Map.Entry<Integer, GarmadonEventDescriptor> out : typeToEventDescriptor.entrySet()) {
+            final Integer eventType = out.getKey();
+            final String eventName = out.getValue().getPath();
+            final Class<? extends Message> clazz = out.getValue().getClazz();
+            final Message.Builder emptyMessageBuilder = out.getValue().getEmptyMessageBuilder();
+            final Function<LocalDateTime, ExpiringConsumer<Message>> consumerBuilder;
+            final Path finalEventDir = new Path(finalHdfsDir, eventName);
+            final OffsetComputer offsetComputer = new HdfsOffsetComputer(fs, finalEventDir, kafkaCluster, backlogDays);
+
+            // When it's day D + 2h, checkpoint for day D - 1m
+            final DelayedDailyPathComputer delayedPathComputer = new DelayedDailyPathComputer(Duration.ofHours(24 + 2));
+            final Checkpointer checkpointer = new FsBasedCheckpointer(fs,
+                (partition, instant) -> {
+                    Path dayDir = new Path(finalEventDir,
+                        delayedPathComputer.apply(instant.atZone(ZoneId.of("UTC"))));
+
+                    return new Path(dayDir, "." + partition.toString() + ".done");
+                });
+
+            consumerBuilder = buildMessageConsumerBuilder(fs, new Path(temporaryHdfsDir, eventName),
+                finalEventDir, clazz, offsetComputer, pauser, eventName);
+
+            final PartitionedWriter<Message> writer = new PartitionedWriter<>(
+                consumerBuilder, offsetComputer, eventName, emptyMessageBuilder, checkpointer);
+
+            readerBuilder.intercept(hasType(eventType), buildGarmadonMessageHandler(writer, eventName));
+
+            writers.add(writer);
+        }
+
+        final List<ConsumerRebalanceListener> listeners = Arrays.asList(
+            new OffsetResetter<>(kafkaConsumer, heartbeat::dropPartition, writers), pauser);
+
+        // We need to build a meta listener as only the last call to #subscribe wins
+        kafkaConsumer.subscribe(Collections.singleton(GarmadonReader.GARMADON_TOPIC),
+            new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    listeners.forEach(listener -> listener.onPartitionsRevoked(partitions));
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    listeners.forEach(listener -> listener.onPartitionsAssigned(partitions));
+                }
+            });
+
+        readerBuilder.intercept(any(), msg -> {
+            heartbeat.handle(msg);
+
+            CommittableOffset offset = msg.getCommittableOffset();
+
+            Gauge.Child gauge = PrometheusMetrics.buildGaugeChild(PrometheusMetrics.CURRENT_RUNNING_OFFSETS,
+                "global", offset.getPartition());
+            gauge.set(offset.getOffset());
+        });
+
+        GarmadonReader reader = readerBuilder.build(false);
+
+        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = (thread, e) -> {
+            LOGGER.error("Interrupting reader " + idx, e);
+            reader.stopReading().whenComplete((t, ex) -> {
+                expirer.stop().join();
+                heartbeat.stop().join();
+            });
+        };
+
+        expirer.start(uncaughtExceptionHandler, "expirer-" + idx);
+        heartbeat.start(uncaughtExceptionHandler, "heartbeat-" + idx);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(reader::stopReading));
+
+        return reader;
+    }
+
+    private Function<LocalDateTime, ExpiringConsumer<Message>> buildMessageConsumerBuilder(
+        FileSystem fs, Path temporaryHdfsDir, Path finalHdfsDir, Class<? extends Message> clazz,
+        OffsetComputer offsetComputer, PartitionsPauseStateHandler partitionsPauser, String eventName) {
+        Counter.Child tmpFileOpenFailures = PrometheusMetrics.buildCounterChild(
+            PrometheusMetrics.TMP_FILE_OPEN_FAILURES, eventName);
+        Counter.Child tmpFilesOpened = PrometheusMetrics.buildCounterChild(
+            PrometheusMetrics.TMP_FILES_OPENED, eventName);
+
+        return dayStartTime -> {
+            final String uniqueFileName = UUID.randomUUID().toString();
+            final String additionalInfo = String.format("Date = %s, Event type = %s", dayStartTime,
+                clazz.getSimpleName());
+
+            for (int i = 0; i < maxTmpFileOpenRetries; ++i) {
+                final Path tmpFilePath = new Path(temporaryHdfsDir, uniqueFileName);
+                final ProtoParquetWriter<Message> protoWriter;
+
+                try {
+                    protoWriter = new ProtoParquetWriter<>(tmpFilePath, clazz, CompressionCodecName.GZIP,
+                        sizeBeforeFlushingTmp * 1_024 * 1_024, 1_024 * 1_024);
+                    tmpFilesOpened.inc();
+                } catch (IOException e) {
+                    LOGGER.warn("Could not initialize writer ({})", additionalInfo, e);
+                    tmpFileOpenFailures.inc();
+
+                    try {
+                        partitionsPauser.pause(clazz);
+                        Thread.sleep(tmpFileOpenRetryPeriod.get(ChronoUnit.SECONDS));
+                    } catch (InterruptedException interrupt) {
+                        LOGGER.info("Interrupted between temp file opening retries", interrupt);
+                    }
+
+                    continue;
+                }
+
+                partitionsPauser.resume(clazz);
+
+                return new ExpiringConsumer<>(new ProtoParquetWriterWithOffset<>(
+                    protoWriter, tmpFilePath, finalHdfsDir, fs, offsetComputer, dayStartTime, eventName),
+                    writersExpirationDelay, messagesBeforeExpiringWriters);
+            }
+
+            // There's definitely something wrong, potentially the whole instance, so stop trying
+            throw new FileSystemNotFoundException(String.format(
+                "Failed opening a temporary file after %d retries: %s",
+                maxTmpFileOpenRetries, additionalInfo));
+        };
+    }
+
+    private GarmadonReader.GarmadonMessageHandler buildGarmadonMessageHandler(PartitionedWriter<Message> writer,
+                                                                              String eventName) {
+        return msg -> {
+            final CommittableOffset offset = msg.getCommittableOffset();
+            final Counter.Child messagesWritingFailures = PrometheusMetrics.buildCounterChild(
+                PrometheusMetrics.MESSAGES_WRITING_FAILURES, eventName, offset.getPartition());
+            final Counter.Child messagesWritten = PrometheusMetrics.buildCounterChild(
+                PrometheusMetrics.MESSAGES_WRITTEN, eventName, offset.getPartition());
+
+            Gauge.Child gauge = PrometheusMetrics.buildGaugeChild(PrometheusMetrics.CURRENT_RUNNING_OFFSETS,
+                eventName, offset.getPartition());
+            gauge.set(offset.getOffset());
+
+            try {
+                writer.write(Instant.ofEpochMilli(msg.getTimestamp()), offset, msg.toProto());
+
+                messagesWritten.inc();
+            } catch (IOException e) {
+                // We accept losing messages every now and then, but still log failures
+                messagesWritingFailures.inc();
+                LOGGER.warn("Couldn't write a message", e);
+            }
+        };
+    }
+
+}

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/configurations/HdfsReaderConfiguration.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/configurations/HdfsReaderConfiguration.java
@@ -7,6 +7,8 @@ public class HdfsReaderConfiguration {
     private HdfsConfiguration hdfs;
     private KafkaConfiguration kafka;
     private PrometheusConfiguration prometheus;
+    private int parallelism;
+
 
     public HdfsConfiguration getHdfs() {
         return hdfs;
@@ -30,5 +32,13 @@ public class HdfsReaderConfiguration {
 
     public void setPrometheus(PrometheusConfiguration prometheus) {
         this.prometheus = prometheus;
+    }
+
+    public int getParallelism() {
+        return parallelism;
+    }
+
+    public void setParallelism(int parallelism) {
+        this.parallelism = parallelism;
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumer.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumer.java
@@ -38,7 +38,7 @@ public class HeartbeatConsumer<MESSAGE_KIND> implements GarmadonReader.GarmadonM
         this.period = period;
     }
 
-    public void start(Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+    public void start(Thread.UncaughtExceptionHandler uncaughtExceptionHandler, String name) {
         runningThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
                 synchronized (latestPartitionsOffset) {
@@ -61,7 +61,7 @@ public class HeartbeatConsumer<MESSAGE_KIND> implements GarmadonReader.GarmadonM
                     break;
                 }
             }
-        });
+        }, name);
 
         runningThread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -301,7 +301,7 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
             this.period = period;
         }
 
-        public void start(Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+        public void start(Thread.UncaughtExceptionHandler uncaughtExceptionHandler, String name) {
             runningThread = new Thread(() -> {
                 while (!Thread.currentThread().isInterrupted()) {
                     writers.forEach(PartitionedWriter::expireConsumers);
@@ -313,7 +313,7 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
                         break;
                     }
                 }
-            });
+            }, name);
 
             runningThread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
             runningThread.start();

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumerTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumerTest.java
@@ -25,7 +25,7 @@ public class HeartbeatConsumerTest {
         final HeartbeatConsumer hb = new HeartbeatConsumer<>(writers, Duration.ofMillis(10));
 
         hb.handle(buildGarmadonMessage(new TopicPartitionOffset(TOPIC, BASE_PARTITION, BASE_OFFSET)));
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
         Thread.sleep(500);
 
         hb.stop().join();
@@ -51,7 +51,7 @@ public class HeartbeatConsumerTest {
         hb.handle(buildGarmadonMessage(secondPartitionSecondOffset));
         hb.handle(buildGarmadonMessage(secondPartitionFirstOffset));
 
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
         Thread.sleep(1000);
 
         for (PartitionedWriter<String> writer: writers) {
@@ -75,7 +75,7 @@ public class HeartbeatConsumerTest {
         final Offset secondOffset = new TopicPartitionOffset(TOPIC, BASE_PARTITION + 1, BASE_OFFSET + 11);
 
         hb.handle(buildGarmadonMessage(firstOffset));
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
         Thread.sleep(1000);
         verify(writer, times(1)).heartbeat(eq(BASE_PARTITION),
                 argThat(new OffsetArgumentMatcher(firstOffset)));
@@ -99,7 +99,7 @@ public class HeartbeatConsumerTest {
         hb.handle(buildGarmadonMessage(secondPartitionOffset));
         hb.dropPartition(BASE_PARTITION);
 
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
 
         Thread.sleep(1000);
 
@@ -121,7 +121,7 @@ public class HeartbeatConsumerTest {
         final HeartbeatConsumer hb = new HeartbeatConsumer<>(writers, Duration.ofMillis(10));
         hb.handle(buildGarmadonMessage(offset));
 
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
 
         verify(writers.get(0), after(100).atLeast(1)).heartbeat(eq(PARTITION),
                 argThat(new OffsetArgumentMatcher(offset)));
@@ -134,7 +134,7 @@ public class HeartbeatConsumerTest {
         final HeartbeatConsumer hb = new HeartbeatConsumer<String>(Collections.singleton(mock(PartitionedWriter.class)),
                 Duration.ofMillis(10));
 
-        hb.start(mock(Thread.UncaughtExceptionHandler.class));
+        hb.start(mock(Thread.UncaughtExceptionHandler.class), "heartbeat");
         Thread.sleep(1000);
         hb.stop().join();
     }

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
@@ -362,7 +362,7 @@ public class PartitionedWriterTest {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(
                 Arrays.asList(firstConsumer, secondConsumer), Duration.ofMillis(1));
 
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class));
+        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
 
         Thread.sleep(500);
 
@@ -379,7 +379,7 @@ public class PartitionedWriterTest {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(Collections.emptyList(),
                 Duration.ofMillis(10));
 
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class));
+        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
         Thread.sleep(500);
         expirer.stop().join();
     }
@@ -389,7 +389,7 @@ public class PartitionedWriterTest {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(
                 Collections.singleton(mock(PartitionedWriter.class)), Duration.ofHours(42));
 
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class));
+        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
         Thread.sleep(1000);
         expirer.stop().join();
     }


### PR DESCRIPTION
Details:
  - if one reader stops, all readers are stopped and the program terminates
  - garmadon reader creation has been moved to a dedicated factory class
  - adapt GarmadonReader to support many instances
  - adapt PrometheusMetrics to support multiple KafkaConsumers