### PR TITLE
[HDFS Reader] Use timestamp of the current day as the default value for latest_committed_timestamp

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -196,10 +197,9 @@ public class ProtoParquetWriterWithOffset<MESSAGE_KIND extends MessageOrBuilder>
         //there are cases for which we won't find a value for the latest committed timestamp
         // - the first time this code goes in, no file has the correct metadata
         // - for a new event type, we have no history too, so no value
-        //By using the default value 'now' rather than 0, we prevent firing unnecessary alerts
-        //However, if there is an actual problem and the reader never commits, it will eventually fire
-        //an alert.
-        long defaultValue = System.currentTimeMillis();
+        // - if started and no file has been create for the day
+        //Using the timestamp of today midnight prevents unnecessary alerts
+        long defaultValue = LocalDateTime.now().toLocalDate().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
         try {
             Optional<Path> latestFileCommitted = getLastestExistingFinalPath();
             if (latestFileCommitted.isPresent()) {

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
@@ -198,8 +198,8 @@ public class ProtoParquetWriterWithOffset<MESSAGE_KIND extends MessageOrBuilder>
         // - the first time this code goes in, no file has the correct metadata
         // - for a new event type, we have no history too, so no value
         // - if started and no file has been create for the day
-        //Using the timestamp of today midnight prevents unnecessary alerts
-        long defaultValue = LocalDateTime.now().toLocalDate().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000;
+        //Using 0 might raise an unwanted alert but should be pretty rare and stop by itself
+        long defaultValue = 0;
         try {
             Optional<Path> latestFileCommitted = getLastestExistingFinalPath();
             if (latestFileCommitted.isPresent()) {

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -328,7 +329,7 @@ public class ProtoParquetWriterWithOffsetTest {
             protoMetadataWriter, 0);
 
         assertEquals(
-            (double) System.currentTimeMillis(),
+            (double) TODAY.toLocalDate().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000,
             PrometheusMetrics.latestCommittedTimestampGauge("eventName", 0).get(),
             1000
         );
@@ -353,7 +354,7 @@ public class ProtoParquetWriterWithOffsetTest {
             protoMetadataWriter, 0);
 
         assertEquals(
-            (double) System.currentTimeMillis(),
+            (double) TODAY.toLocalDate().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000,
             PrometheusMetrics.latestCommittedTimestampGauge("eventName", 0).get(),
             1000
         );
@@ -373,7 +374,7 @@ public class ProtoParquetWriterWithOffsetTest {
         doThrow(new IOException()).when(localFsSpy).globStatus(any(Path.class));
 
         assertEquals(
-            (double) System.currentTimeMillis(),
+            (double) TODAY.toLocalDate().atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000,
             PrometheusMetrics.latestCommittedTimestampGauge("eventName", 0).get(),
             1000
         );


### PR DESCRIPTION
Details: we faced the case of constant failures during file committing, that induced restart of reader instances
Those restart led to think that latest committed timestamp was making progress, which was fake.

Using a constant value for the day, across restart will help to catch such issue.