### PR TITLE
Fix undesired latest_committed_timestamps value at 0

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffset.java
@@ -187,9 +187,8 @@ public class ProtoParquetWriterWithOffset<MESSAGE_KIND extends MessageOrBuilder>
 
 
     private void initializeLatestCommittedTimestampGauge() {
-        if (PrometheusMetrics.latestCommittedTimestampGauge(eventName, partition).get() == 0) {
-            PrometheusMetrics.latestCommittedTimestampGauge(eventName, partition).set(getLatestCommittedTimestamp());
-        }
+        double timestamp = getLatestCommittedTimestamp();
+        PrometheusMetrics.latestCommittedTimestampGauge(eventName, partition).set(timestamp);
     }
 
     private double getLatestCommittedTimestamp() {


### PR DESCRIPTION
latest_committed_timestamps can be long to set the initial value and during this interval, the gauge will display 0.
With this commit we will always set the field according to what exists on HDFS and the vlue is calculated befor esetting the gauge.