### PR TITLE
Fix undesired Kafka rebalance when creating ExpiringConsumer

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -242,11 +242,13 @@ public class ReaderFactory {
                     continue;
                 }
 
-                partitionsPauser.resume(clazz);
-
-                return new ExpiringConsumer<>(new ProtoParquetWriterWithOffset<>(
+                ExpiringConsumer consumer = new ExpiringConsumer<>(new ProtoParquetWriterWithOffset<>(
                     protoWriter, tmpFilePath, finalHdfsDir, fs, offsetComputer, dayStartTime, eventName, extraMetadataWriteSupport, partition),
                     writersExpirationDelay, messagesBeforeExpiringWriters);
+
+                partitionsPauser.resume(clazz);
+
+                return consumer;
             }
 
             // There's definitely something wrong, potentially the whole instance, so stop trying


### PR DESCRIPTION
ExpiringConsumer creation can take time since the latest committed timestamp is taken from the footer of a parquet file on HDFS. This time can get so long that kafka assumes the consumer is dead.
This fix move the partitionPauser.resume after the creation of the ExpiringConsumer.