### PR TITLE
[HDFS-READER] Solve deadlock issue

### DIFF
--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/CommittableOffset.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/CommittableOffset.java
@@ -1,5 +1,6 @@
 package com.criteo.hadoop.garmadon.reader;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
@@ -18,12 +19,12 @@ import java.util.concurrent.CompletableFuture;
  */
 public class CommittableOffset<K, V> implements Offset {
 
-    private final GarmadonReader.SynchronizedConsumer<K, V> consumer;
+    private final Consumer<K, V> consumer;
     private final String topic;
     private final int partition;
     private final long lastProcessedOffset;
 
-    public CommittableOffset(GarmadonReader.SynchronizedConsumer<K, V> consumer, String topic, int partition, long lastProcessedOffset) {
+    public CommittableOffset(Consumer<K, V> consumer, String topic, int partition, long lastProcessedOffset) {
         this.consumer = consumer;
         this.topic = topic;
         this.partition = partition;

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
@@ -18,6 +18,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAmount;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,9 +55,9 @@ public final class GarmadonReader {
     private boolean reading = false;
 
     private GarmadonReader(Consumer<String, byte[]> kafkaConsumer, List<GarmadonMessageHandler> beforeInterceptHandlers,
-                           Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners, int id) {
+                           Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, int id) {
         this.cf = new CompletableFuture<>();
-        this.reader = new Reader(kafkaConsumer, beforeInterceptHandlers, listeners, cf);
+        this.reader = new Reader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions, cf);
         this.id = id;
     }
 
@@ -86,9 +88,31 @@ public final class GarmadonReader {
         }
     }
 
+    public static class RecurrentAction {
+        private final TemporalAmount period;
+        private final Runnable action;
+
+        private LocalDateTime nextRunTimestamp;
+
+        public RecurrentAction(Runnable action, TemporalAmount period) {
+            this.action = action;
+            this.period = period;
+            nextRunTimestamp = LocalDateTime.now();
+        }
+
+        public void run() {
+            LocalDateTime current = LocalDateTime.now();
+            if (current.isAfter(nextRunTimestamp)) {
+                nextRunTimestamp = current.plus(period);
+                action.run();
+            }
+        }
+    }
+
     protected static class Reader implements Runnable {
 
         private final SynchronizedConsumer<String, byte[]> consumer;
+        private final List<RecurrentAction> recurrentActions;
         private final CompletableFuture<Void> cf;
         private final List<GarmadonMessageHandler> beforeInterceptHandlers;
         private final Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners;
@@ -99,11 +123,12 @@ public final class GarmadonReader {
         private volatile boolean keepOnReading = true;
 
         Reader(Consumer<String, byte[]> consumer, List<GarmadonMessageHandler> beforeInterceptHandlers, Map<GarmadonMessageFilter,
-            GarmadonMessageHandler> listeners, CompletableFuture<Void> cf) {
+            GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, CompletableFuture<Void> cf) {
             this.consumer = SynchronizedConsumer.synchronize(consumer);
             this.beforeInterceptHandlers = beforeInterceptHandlers;
             this.listeners = listeners;
             this.filters = listeners.keySet();
+            this.recurrentActions = recurrentActions;
             this.cf = cf;
         }
 
@@ -114,6 +139,7 @@ public final class GarmadonReader {
                 LOGGER.info("initialize reading");
 
                 while (keepOnReading) {
+                    recurrentActions.forEach(RecurrentAction::run);
                     readConsumerRecords();
                 }
             } catch (Exception e) {
@@ -263,8 +289,9 @@ public final class GarmadonReader {
         public static final Properties DEFAULT_KAFKA_PROPS = new Properties();
 
         private final Consumer<String, byte[]> kafkaConsumer;
-        private Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners = new HashMap<>();
-        private List<GarmadonMessageHandler> beforeInterceptHandlers = new ArrayList<>();
+        private final Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners = new HashMap<>();
+        private final List<GarmadonMessageHandler> beforeInterceptHandlers = new ArrayList<>();
+        private final List<RecurrentAction> recurrentActions = new ArrayList<>();
 
         static {
             DEFAULT_KAFKA_PROPS.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString()); //by default groupId is random
@@ -296,6 +323,11 @@ public final class GarmadonReader {
             return this;
         }
 
+        public Builder recurring(Runnable action, TemporalAmount period) {
+            recurrentActions.add(new RecurrentAction(action, period));
+            return this;
+        }
+
         public GarmadonReader build() {
             return this.build(true);
         }
@@ -303,7 +335,7 @@ public final class GarmadonReader {
         public GarmadonReader build(boolean autoSubscribe) {
             if (autoSubscribe) kafkaConsumer.subscribe(Collections.singletonList(GARMADON_TOPIC));
 
-            return new GarmadonReader(kafkaConsumer, beforeInterceptHandlers, listeners, READER_IDX.getAndIncrement());
+            return new GarmadonReader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions, READER_IDX.getAndIncrement());
         }
     }
 

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
@@ -111,7 +111,7 @@ public final class GarmadonReader {
 
     protected static class Reader implements Runnable {
 
-        private final SynchronizedConsumer<String, byte[]> consumer;
+        private final Consumer<String, byte[]> consumer;
         private final List<RecurrentAction> recurrentActions;
         private final CompletableFuture<Void> cf;
         private final List<GarmadonMessageHandler> beforeInterceptHandlers;
@@ -124,7 +124,7 @@ public final class GarmadonReader {
 
         Reader(Consumer<String, byte[]> consumer, List<GarmadonMessageHandler> beforeInterceptHandlers, Map<GarmadonMessageFilter,
             GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, CompletableFuture<Void> cf) {
-            this.consumer = SynchronizedConsumer.synchronize(consumer);
+            this.consumer = consumer;
             this.beforeInterceptHandlers = beforeInterceptHandlers;
             this.listeners = listeners;
             this.filters = listeners.keySet();
@@ -251,37 +251,6 @@ public final class GarmadonReader {
             int get() {
                 return count;
             }
-        }
-    }
-
-    static final class SynchronizedConsumer<K, V> {
-
-        private final Consumer<K, V> consumer;
-
-        private SynchronizedConsumer(Consumer<K, V> consumer) {
-            this.consumer = consumer;
-        }
-
-        synchronized ConsumerRecords<K, V> poll(long timeout) {
-            synchronized (consumer) {
-                return consumer.poll(timeout);
-            }
-        }
-
-        synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
-            synchronized (consumer) {
-                consumer.commitSync(offsets);
-            }
-        }
-
-        synchronized void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
-            synchronized (consumer) {
-                consumer.commitAsync(offsets, callback);
-            }
-        }
-
-        static <K, V> SynchronizedConsumer<K, V> synchronize(Consumer<K, V> consumer) {
-            return new SynchronizedConsumer<>(consumer);
         }
     }
 

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
@@ -6,7 +6,6 @@ import com.criteo.hadoop.garmadon.schema.exceptions.DeserializationException;
 import com.criteo.hadoop.garmadon.schema.serialization.GarmadonSerialization;
 import com.google.protobuf.Message;
 import org.apache.kafka.clients.consumer.*;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;

--- a/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
+++ b/readers/common/src/main/java/com/criteo/hadoop/garmadon/reader/GarmadonReader.java
@@ -54,9 +54,10 @@ public final class GarmadonReader {
     private boolean reading = false;
 
     private GarmadonReader(Consumer<String, byte[]> kafkaConsumer, List<GarmadonMessageHandler> beforeInterceptHandlers,
-                           Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, int id) {
+                           Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions,
+                           List<Runnable> postReadingActions, int id) {
         this.cf = new CompletableFuture<>();
-        this.reader = new Reader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions, cf);
+        this.reader = new Reader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions, postReadingActions, cf);
         this.id = id;
     }
 
@@ -112,6 +113,7 @@ public final class GarmadonReader {
 
         private final Consumer<String, byte[]> consumer;
         private final List<RecurrentAction> recurrentActions;
+        private List<Runnable> postReadingActions;
         private final CompletableFuture<Void> cf;
         private final List<GarmadonMessageHandler> beforeInterceptHandlers;
         private final Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners;
@@ -122,12 +124,14 @@ public final class GarmadonReader {
         private volatile boolean keepOnReading = true;
 
         Reader(Consumer<String, byte[]> consumer, List<GarmadonMessageHandler> beforeInterceptHandlers, Map<GarmadonMessageFilter,
-            GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, CompletableFuture<Void> cf) {
+            GarmadonMessageHandler> listeners, List<RecurrentAction> recurrentActions, List<Runnable> postReadingActions,
+            CompletableFuture<Void> cf) {
             this.consumer = consumer;
             this.beforeInterceptHandlers = beforeInterceptHandlers;
             this.listeners = listeners;
             this.filters = listeners.keySet();
             this.recurrentActions = recurrentActions;
+            this.postReadingActions = postReadingActions;
             this.cf = cf;
         }
 
@@ -146,10 +150,25 @@ public final class GarmadonReader {
                 cf.completeExceptionally(e);
             }
 
+            final RuntimeException firstExceptionDuringPostReadingActions = new RuntimeException("failed to run successfuly post reading actions");
+
+            postReadingActions.forEach(r -> {
+                try {
+                    r.run();
+                } catch (Exception e) {
+                    firstExceptionDuringPostReadingActions.addSuppressed(e);
+                    LOGGER.error(e.getMessage(), e);
+                }
+            });
+
             LOGGER.info("stopped reading");
             cf.complete(null);
 
             LOGGER.info("received {} messages", receivedCounter.get());
+
+            if (firstExceptionDuringPostReadingActions.getSuppressed().length > 0) {
+                throw firstExceptionDuringPostReadingActions;
+            }
         }
 
         protected void readConsumerRecords() {
@@ -260,6 +279,7 @@ public final class GarmadonReader {
         private final Map<GarmadonMessageFilter, GarmadonMessageHandler> listeners = new HashMap<>();
         private final List<GarmadonMessageHandler> beforeInterceptHandlers = new ArrayList<>();
         private final List<RecurrentAction> recurrentActions = new ArrayList<>();
+        private final List<Runnable> postReadingActions = new ArrayList<>();
 
         static {
             DEFAULT_KAFKA_PROPS.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString()); //by default groupId is random
@@ -296,6 +316,11 @@ public final class GarmadonReader {
             return this;
         }
 
+        public Builder postReadingHook(Runnable action) {
+            postReadingActions.add(action);
+            return this;
+        }
+
         public GarmadonReader build() {
             return this.build(true);
         }
@@ -303,7 +328,8 @@ public final class GarmadonReader {
         public GarmadonReader build(boolean autoSubscribe) {
             if (autoSubscribe) kafkaConsumer.subscribe(Collections.singletonList(GARMADON_TOPIC));
 
-            return new GarmadonReader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions, READER_IDX.getAndIncrement());
+            return new GarmadonReader(kafkaConsumer, beforeInterceptHandlers, listeners, recurrentActions,
+                    postReadingActions, READER_IDX.getAndIncrement());
         }
     }
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -228,8 +228,10 @@ public class ReaderFactory {
             gauge.set(offset.getOffset());
         });
 
-        readerBuilder.recurring(heartbeat::run, heartbeatPeriod);
-        readerBuilder.recurring(expirer::run, expirerPeriod);
+        readerBuilder
+                .recurring(heartbeat::run, heartbeatPeriod)
+                .recurring(expirer::run, expirerPeriod)
+                .postReadingHook(expirer::stop);
 
         GarmadonReader reader = readerBuilder.build(false);
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -228,18 +228,10 @@ public class ReaderFactory {
             gauge.set(offset.getOffset());
         });
 
+        readerBuilder.recurring(heartbeat::run, heartbeatPeriod);
+        readerBuilder.recurring(expirer::run, expirerPeriod);
+
         GarmadonReader reader = readerBuilder.build(false);
-
-        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = (thread, e) -> {
-            LOGGER.error("Interrupting reader " + idx, e);
-            reader.stopReading().whenComplete((t, ex) -> {
-                expirer.stop().join();
-                heartbeat.stop().join();
-            });
-        };
-
-        expirer.start(uncaughtExceptionHandler, "expirer-" + idx);
-        heartbeat.start(uncaughtExceptionHandler, "heartbeat-" + idx);
 
         Runtime.getRuntime().addShutdownHook(new Thread(reader::stopReading));
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -230,10 +230,13 @@ public class ReaderFactory {
 
         readerBuilder
                 .recurring(heartbeat::run, heartbeatPeriod)
-                .recurring(expirer::run, expirerPeriod)
-                .postReadingHook(expirer::stop);
+                .recurring(expirer::run, expirerPeriod);
 
         GarmadonReader reader = readerBuilder.build(false);
+
+        reader.getCompletableFuture().whenComplete((v, t) -> {
+            expirer.stop();
+        });
 
         Runtime.getRuntime().addShutdownHook(new Thread(reader::stopReading));
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
@@ -44,18 +44,21 @@ public class PartitionsPauseStateHandler implements ConsumerRebalanceListener {
     }
 
     public void pause(Class pausingEvent) {
-        synchronized (consumer) {
-            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
-
+        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) {
+            synchronized (consumer) {
+                consumer.pause(currentlyAssignedPartitions);
+            }
             pausedEvents.add(pausingEvent);
         }
     }
 
     public void resume(Class resumingEvent) {
-        synchronized (consumer) {
-            pausedEvents.remove(resumingEvent);
+        pausedEvents.remove(resumingEvent);
 
-            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.resume(currentlyAssignedPartitions);
+        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) {
+            synchronized (consumer) {
+                consumer.resume(currentlyAssignedPartitions);
+            }
         }
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
@@ -44,21 +44,18 @@ public class PartitionsPauseStateHandler implements ConsumerRebalanceListener {
     }
 
     public void pause(Class pausingEvent) {
-        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) {
-            synchronized (consumer) {
-                consumer.pause(currentlyAssignedPartitions);
-            }
+        synchronized (consumer) {
+            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
+
             pausedEvents.add(pausingEvent);
         }
     }
 
     public void resume(Class resumingEvent) {
-        pausedEvents.remove(resumingEvent);
+        synchronized (consumer) {
+            pausedEvents.remove(resumingEvent);
 
-        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) {
-            synchronized (consumer) {
-                consumer.resume(currentlyAssignedPartitions);
-            }
+            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.resume(currentlyAssignedPartitions);
         }
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/kafka/PartitionsPauseStateHandler.java
@@ -29,33 +29,25 @@ public class PartitionsPauseStateHandler implements ConsumerRebalanceListener {
 
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-        synchronized (consumer) {
-            currentlyAssignedPartitions.removeAll(partitions);
-        }
+        currentlyAssignedPartitions.removeAll(partitions);
     }
 
     @Override
     public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-        synchronized (consumer) {
-            currentlyAssignedPartitions.addAll(partitions);
+        currentlyAssignedPartitions.addAll(partitions);
 
-            if (!pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
-        }
+        if (!pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
     }
 
     public void pause(Class pausingEvent) {
-        synchronized (consumer) {
-            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
+        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.pause(currentlyAssignedPartitions);
 
-            pausedEvents.add(pausingEvent);
-        }
+        pausedEvents.add(pausingEvent);
     }
 
     public void resume(Class resumingEvent) {
-        synchronized (consumer) {
-            pausedEvents.remove(resumingEvent);
+        pausedEvents.remove(resumingEvent);
 
-            if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.resume(currentlyAssignedPartitions);
-        }
+        if (pausedEvents.isEmpty() && !currentlyAssignedPartitions.isEmpty()) consumer.resume(currentlyAssignedPartitions);
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumer.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumer.java
@@ -8,12 +8,10 @@ import com.criteo.hadoop.garmadon.reader.Offset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Send periodic heartbeats to a collection of writers, only if different from previous heartbeat

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -271,7 +271,6 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
     public static class Expirer<MESSAGE_KIND> {
         private final Collection<PartitionedWriter<MESSAGE_KIND>> writers;
         private final TemporalAmount period;
-        private volatile Thread runningThread;
 
         /**
          * @param writers Writers to watch for

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -285,7 +285,7 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
         public void start(Thread.UncaughtExceptionHandler uncaughtExceptionHandler, String name) {
             runningThread = new Thread(() -> {
                 while (!Thread.currentThread().isInterrupted()) {
-                    writers.forEach(PartitionedWriter::expireConsumers);
+                    run();
 
                     try {
                         Thread.sleep(period.get(ChronoUnit.SECONDS) * 1000);
@@ -298,6 +298,10 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
 
             runningThread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
             runningThread.start();
+        }
+
+        public void run() {
+            writers.forEach(PartitionedWriter::expireConsumers);
         }
 
         /**

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -283,5 +283,20 @@ public class PartitionedWriter<MESSAGE_KIND> implements Closeable {
         public void run() {
             writers.forEach(PartitionedWriter::expireConsumers);
         }
+
+        public void stop() {
+            final RuntimeException exception = new RuntimeException("failed to stop writers");
+            writers.forEach(w -> {
+                try {
+                    w.close();
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
+                    exception.addSuppressed(e);
+                }
+            });
+            if (exception.getSuppressed().length > 0) {
+                throw exception;
+            }
+        }
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriter.java
@@ -23,7 +23,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumerTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/offset/HeartbeatConsumerTest.java
@@ -76,7 +76,7 @@ public class HeartbeatConsumerTest {
                 argThat(new OffsetArgumentMatcher(firstOffset)));
 
         hb.handle(buildGarmadonMessage(secondOffset));
-        Thread.sleep(1000);
+        hb.run();
         verify(writer, times(1)).heartbeat(eq(BASE_PARTITION + 1),
                 argThat(new OffsetArgumentMatcher(secondOffset)));
     }

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
@@ -369,9 +369,6 @@ public class PartitionedWriterTest {
 
         verify(firstConsumer, atLeastOnce()).expireConsumers();
         verify(secondConsumer, atLeastOnce()).expireConsumers();
-
-        verify(firstConsumer, atLeastOnce()).close();
-        verify(secondConsumer, atLeastOnce()).close();
     }
 
     @Test(timeout = 3000)

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/PartitionedWriterTest.java
@@ -365,14 +365,11 @@ public class PartitionedWriterTest {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(
                 Arrays.asList(firstConsumer, secondConsumer), Duration.ofMillis(1));
 
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
-
-        Thread.sleep(500);
+        expirer.run();
 
         verify(firstConsumer, atLeastOnce()).expireConsumers();
         verify(secondConsumer, atLeastOnce()).expireConsumers();
 
-        expirer.stop().join();
         verify(firstConsumer, atLeastOnce()).close();
         verify(secondConsumer, atLeastOnce()).close();
     }
@@ -381,10 +378,7 @@ public class PartitionedWriterTest {
     public void writerExpirerWithNoWriter() throws InterruptedException {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(Collections.emptyList(),
                 Duration.ofMillis(10));
-
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
-        Thread.sleep(500);
-        expirer.stop().join();
+        expirer.run();
     }
 
     @Test(timeout = 3000)
@@ -392,9 +386,7 @@ public class PartitionedWriterTest {
         final PartitionedWriter.Expirer<String> expirer = new PartitionedWriter.Expirer<>(
                 Collections.singleton(mock(PartitionedWriter.class)), Duration.ofHours(42));
 
-        expirer.start(mock(Thread.UncaughtExceptionHandler.class), "expirer");
-        Thread.sleep(1000);
-        expirer.stop().join();
+        expirer.run();
     }
 
     private static Offset buildOffset(int partitionId, long offsetValue) {


### PR DESCRIPTION
run heartbeat and expirer in the same thread as garmadon reader to avoid deadlock issues.
reduce the scope of some synchronized blocks.