### PR TITLE
Fix missing artifact hadoop-lzo

### DIFF
--- a/readers/hdfs/pom.xml
+++ b/readers/hdfs/pom.xml
@@ -24,6 +24,12 @@
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-protobuf</artifactId>
             <version>${parquet-protobuf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.hadoop.gplcompression</groupId>
+                    <artifactId>hadoop-lzo</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
applied the same exclusion as https://issues.apache.org/jira/browse/PARQUET-1691
https://github.com/apache/parquet-mr/pull/698
https://github.com/twitter/hadoop-lzo/issues/140
temporary fix until parquet 1.11.0 get released.