### PR TITLE
Merge parquet files row by row to avoid stacking RowGroups

### DIFF
--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
@@ -386,7 +386,7 @@ public class ProtoParquetWriterWithOffsetTest {
 
     private <M extends Message> void createParquetFile(Path p, Class<M> clazz, Supplier<M> msgBuilder, Optional<Long> latestCommittedTimestamp) throws IOException {
         ExtraMetadataWriteSupport extraMetadataWriteSupport = new ExtraMetadataWriteSupport<>(new ProtoWriteSupport<>(clazz));
-        ParquetWriter<Message> writer = new ParquetWriter<>(p, extraMetadataWriteSupport, CompressionCodecName.SNAPPY,
+        ParquetWriter<Message> writer = new     ParquetWriter<>(p, extraMetadataWriteSupport, CompressionCodecName.SNAPPY,
             1_024 * 1_024, 1_024 * 1_024);
 
         writer.write(msgBuilder.get());

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/writer/ProtoParquetWriterWithOffsetTest.java
@@ -386,7 +386,7 @@ public class ProtoParquetWriterWithOffsetTest {
 
     private <M extends Message> void createParquetFile(Path p, Class<M> clazz, Supplier<M> msgBuilder, Optional<Long> latestCommittedTimestamp) throws IOException {
         ExtraMetadataWriteSupport extraMetadataWriteSupport = new ExtraMetadataWriteSupport<>(new ProtoWriteSupport<>(clazz));
-        ParquetWriter<Message> writer = new     ParquetWriter<>(p, extraMetadataWriteSupport, CompressionCodecName.SNAPPY,
+        ParquetWriter<Message> writer = new ParquetWriter<>(p, extraMetadataWriteSupport, CompressionCodecName.SNAPPY,
             1_024 * 1_024, 1_024 * 1_024);
 
         writer.write(msgBuilder.get());


### PR DESCRIPTION
Merge methods only append row groups. The merge processing results in creating files with thousands of rowGroups. Beside creating memory issues, this also creates very inefficient parquet files.

Instead we should read row by row and write row by row in the destination