### PR TITLE
Add usage of ES index lifecycle on top of garmadon indexes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,9 @@ Garmadon-readers-elasticsearch's jar can be fetch from maven central:
    bulkActions: 500                        # OPTIONAL: Flush bulk every bulkActions event (DEFAULT: 500)
    bulkSizeMB: 5                           # OPTIONAL: Flush bulk ever bulkSizeMB mb (DEFAULT: 5)
    bulkFlushIntervalSec: 10                # OPTIONAL: Flush bulk ever bulkFlushIntervalSec s (DEFAULT: 10)
+   ilmForceMerge: false                    # OPTIONAL: Force merge of segment to 1 during warm phase of the garmadon life cycle policy         
+   ilmTimingDayForWarmPhase: 2             # Number of days before moving index to ilm warm phase (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html)
+   ilmTimingDayForDeletePhase: 4           # Number of days before deleting index
    settings:                               # Any index settings to put on the garmadon template
      index.number_of_shards: 10
      index.number_of_replicas: 2

--- a/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/configurations/ElasticsearchConfiguration.java
+++ b/readers/elasticsearch/src/main/java/com/criteo/hadoop/garmadon/elasticsearch/configurations/ElasticsearchConfiguration.java
@@ -13,6 +13,9 @@ public class ElasticsearchConfiguration {
     private int bulkActions = 500;
     private int bulkSizeMB = 5;
     private int bulkFlushIntervalSec = 10;
+    private boolean ilmForceMerge = false;
+    private int ilmTimingDayForWarmPhase;
+    private int ilmTimingDayForDeletePhase;
     private Map<String, String> settings = new HashMap<>();
 
     public String getHost() {
@@ -93,5 +96,29 @@ public class ElasticsearchConfiguration {
 
     public void setSettings(Map<String, String> settings) {
         this.settings = settings;
+    }
+
+    public boolean isIlmForceMerge() {
+        return ilmForceMerge;
+    }
+
+    public void setIlmForceMerge(boolean ilmForceMerge) {
+        this.ilmForceMerge = ilmForceMerge;
+    }
+
+    public int getIlmTimingDayForWarmPhase() {
+        return ilmTimingDayForWarmPhase;
+    }
+
+    public void setIlmTimingDayForWarmPhase(int ilmTimingDayForWarmPhase) {
+        this.ilmTimingDayForWarmPhase = ilmTimingDayForWarmPhase;
+    }
+
+    public int getIlmTimingDayForDeletePhase() {
+        return ilmTimingDayForDeletePhase;
+    }
+
+    public void setIlmTimingDayForDeletePhase(int ilmTimingDayForDeletePhase) {
+        this.ilmTimingDayForDeletePhase = ilmTimingDayForDeletePhase;
     }
 }

--- a/readers/elasticsearch/src/test/resources/garmadon-config.yml
+++ b/readers/elasticsearch/src/test/resources/garmadon-config.yml
@@ -4,6 +4,9 @@ elasticsearch:
   user: esuser                            # ES username
   password: espassword                    # ES password
   bulkSizeMB: 10
+  ilmForceMerge: true
+  ilmTimingDayForWarmPhase: 2
+  ilmTimingDayForDeletePhase: 4
   settings:                               # Any index settings to put on the garmadon template
     index.number_of_shards: 10
     index.number_of_replicas: 2

--- a/test/src/main/docker/garmadon/conf-es-reader/garmadon-config.yml
+++ b/test/src/main/docker/garmadon/conf-es-reader/garmadon-config.yml
@@ -3,6 +3,9 @@ elasticsearch:
   port: 9200                              # ES port
   user: esuser                            # ES username
   password: espassword                    # ES password
+  ilmForceMerge: true
+  ilmTimingDayForWarmPhase: 2
+  ilmTimingDayForDeletePhase: 4
   settings:                               # Any index settings to put on the garmadon template
     index.number_of_shards: 10
     index.number_of_replicas: 2


### PR DESCRIPTION
Index management will now rely on ES ILM mechanism (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html) to avoid having to maintain different external processes