### PR TITLE
Send messages to any partitions but some configured types

### DIFF
--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -48,14 +48,15 @@ public class Forwarder {
     private KafkaService kafkaService;
 
     //What type of message should be sent to all partitions
-    private Set<Integer> broadCastedTypes;
+    private Set<Integer> broadcastedTypes;
 
     public Forwarder(Properties properties) {
         this.properties = properties;
 
-        this.broadCastedTypes = Arrays.stream(properties
+        this.broadcastedTypes = Arrays.stream(properties
             .getProperty("broadcasted.message.types", "")
             .split(","))
+            .filter(s -> !s.isEmpty())
             .map(typeName -> {
                 try {
                     return GarmadonSerialization.getMarker(typeName);
@@ -146,7 +147,7 @@ public class Forwarder {
                 // TODO: Test the Unix Domain Socket implementation will need junixsocket at client side....
                 // But should increase perf
                 //.channel(EpollServerDomainSocketChannel.class)
-                .childHandler(new ForwarderChannelInitializer(kafkaService, broadCastedTypes));
+                .childHandler(new ForwarderChannelInitializer(kafkaService, broadcastedTypes));
 
         //start server
         LOGGER.info("Startup netty server");

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -7,6 +7,8 @@ import com.criteo.hadoop.garmadon.forwarder.metrics.HostStatistics;
 import com.criteo.hadoop.garmadon.forwarder.metrics.PrometheusHttpMetrics;
 import com.criteo.hadoop.garmadon.schema.events.Header;
 import com.criteo.hadoop.garmadon.schema.events.HeaderUtils;
+import com.criteo.hadoop.garmadon.schema.exceptions.TypeMarkerException;
+import com.criteo.hadoop.garmadon.schema.serialization.GarmadonSerialization;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -19,7 +21,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Forwarder {
     public static final String PRODUCER_PREFIX_NAME = "garmadon.forwarder";
@@ -42,8 +47,23 @@ public class Forwarder {
     private Channel serverChannel;
     private KafkaService kafkaService;
 
+    //What type of message should be sent to all partitions
+    private Set<Integer> broadCastedTypes;
+
     public Forwarder(Properties properties) {
         this.properties = properties;
+
+        this.broadCastedTypes = Arrays.stream(properties
+            .getProperty("broadcasted.message.types", "")
+            .split(","))
+            .map(typeName -> {
+                try {
+                    return GarmadonSerialization.getMarker(typeName);
+                } catch (TypeMarkerException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .collect(Collectors.toSet());
 
         Header.Builder headerBuilder = Header.newBuilder()
                 .withId(HeaderUtils.getId())
@@ -126,7 +146,7 @@ public class Forwarder {
                 // TODO: Test the Unix Domain Socket implementation will need junixsocket at client side....
                 // But should increase perf
                 //.channel(EpollServerDomainSocketChannel.class)
-                .childHandler(new ForwarderChannelInitializer(kafkaService));
+                .childHandler(new ForwarderChannelInitializer(kafkaService, broadCastedTypes));
 
         //start server
         LOGGER.info("Startup netty server");

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/channel/ForwarderChannelInitializer.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/channel/ForwarderChannelInitializer.java
@@ -5,12 +5,16 @@ import com.criteo.hadoop.garmadon.forwarder.kafka.KafkaService;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 
+import java.util.Set;
+
 public class ForwarderChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private final KafkaService kafkaService;
+    private final Set<Integer> broadCastedTypes;
 
-    public ForwarderChannelInitializer(KafkaService kafkaService) {
+    public ForwarderChannelInitializer(KafkaService kafkaService, Set<Integer> broadCastedTypes) {
         this.kafkaService = kafkaService;
+        this.broadCastedTypes = broadCastedTypes;
     }
 
     @Override
@@ -19,7 +23,7 @@ public class ForwarderChannelInitializer extends ChannelInitializer<SocketChanne
                 .addLast(GreetingDecoder.class.getSimpleName(), new GreetingDecoder())
                 .addLast(GreetingHandler.class.getSimpleName(), new GreetingHandler())
                 .addLast(EventDecoder.class.getSimpleName(), new EventDecoder())
-                .addLast(EventHandler.class.getSimpleName(), new EventHandler())
+                .addLast(EventHandler.class.getSimpleName(), new EventHandler(broadCastedTypes))
                 .addLast(KafkaHandler.class.getSimpleName(), new KafkaHandler(kafkaService));
     }
 }

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/channel/ForwarderChannelInitializer.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/channel/ForwarderChannelInitializer.java
@@ -10,11 +10,11 @@ import java.util.Set;
 public class ForwarderChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private final KafkaService kafkaService;
-    private final Set<Integer> broadCastedTypes;
+    private final Set<Integer> broadcastedTypes;
 
-    public ForwarderChannelInitializer(KafkaService kafkaService, Set<Integer> broadCastedTypes) {
+    public ForwarderChannelInitializer(KafkaService kafkaService, Set<Integer> broadcastedTypes) {
         this.kafkaService = kafkaService;
-        this.broadCastedTypes = broadCastedTypes;
+        this.broadcastedTypes = broadcastedTypes;
     }
 
     @Override
@@ -23,7 +23,7 @@ public class ForwarderChannelInitializer extends ChannelInitializer<SocketChanne
                 .addLast(GreetingDecoder.class.getSimpleName(), new GreetingDecoder())
                 .addLast(GreetingHandler.class.getSimpleName(), new GreetingHandler())
                 .addLast(EventDecoder.class.getSimpleName(), new EventDecoder())
-                .addLast(EventHandler.class.getSimpleName(), new EventHandler(broadCastedTypes))
+                .addLast(EventHandler.class.getSimpleName(), new EventHandler(broadcastedTypes))
                 .addLast(KafkaHandler.class.getSimpleName(), new KafkaHandler(kafkaService));
     }
 }

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/handler/CloseHandler.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/handler/CloseHandler.java
@@ -24,7 +24,6 @@ public class CloseHandler extends ChannelInboundHandlerAdapter {
                     .build();
 
             KafkaMessage kafkaMessage = new KafkaMessage(
-                    header.getApplicationId(),
                     ProtocolMessage.create(System.currentTimeMillis(), header.toByteArray(), stateEvent)
             );
 

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/handler/KafkaHandler.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/handler/KafkaHandler.java
@@ -26,7 +26,7 @@ public class KafkaHandler extends SimpleChannelInboundHandler<KafkaMessage> {
         int type = ByteBuffer.wrap(msg.getValue(), 0, 4).getInt(0);
         PrometheusHttpMetrics.eventSize(type).observe(msg.getValue().length);
 
-        kafkaService.sendRecordAsync(msg.getKey(), msg.getValue());
+        kafkaService.sendRecordAsync(msg.getValue(), msg.isBroadCasted());
     }
 
     @Override

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
@@ -26,7 +26,7 @@ public class KafkaService {
                 send(new ProducerRecord<>(topic, partition.partition(), null, value));
             });
         } else {
-            send(new ProducerRecord<>(topic, null, value));
+            send(new ProducerRecord<>(topic, value));
         }
     }
 

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
@@ -20,9 +20,17 @@ public class KafkaService {
         this.producer = new KafkaProducer<>(properties);
     }
 
-    public void sendRecordAsync(String key, byte[] value) {
-        ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, key, value);
+    public void sendRecordAsync(byte[] value, boolean broadcasted) {
+        if (broadcasted) {
+            producer.partitionsFor(topic).forEach(partition -> {
+                send(new ProducerRecord<>(topic, partition.partition(), null, value));
+            });
+        } else {
+            send(new ProducerRecord<>(topic, null, value));
+        }
+    }
 
+    private void send(ProducerRecord<String, byte[]> record) {
         // TODO manage retry? and exception
         // Check batching, time and kafka config
         producer.send(record, (metadata, exception) -> {

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/message/BroadCastedKafkaMessage.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/message/BroadCastedKafkaMessage.java
@@ -1,0 +1,14 @@
+package com.criteo.hadoop.garmadon.forwarder.message;
+
+public class BroadCastedKafkaMessage extends KafkaMessage {
+
+    public BroadCastedKafkaMessage(byte[] value) {
+        super(value);
+    }
+
+    @Override
+    public boolean isBroadCasted() {
+        return true;
+    }
+
+}

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/message/KafkaMessage.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/message/KafkaMessage.java
@@ -5,20 +5,18 @@ import java.util.Objects;
 
 public class KafkaMessage {
 
-    private final String key;
     private final byte[] value;
 
-    public KafkaMessage(String key, byte[] value) {
-        this.key = key;
+    public KafkaMessage(byte[] value) {
         this.value = value;
-    }
-
-    public String getKey() {
-        return key;
     }
 
     public byte[] getValue() {
         return value;
+    }
+
+    public boolean isBroadCasted() {
+        return false;
     }
 
     @Override
@@ -26,12 +24,11 @@ public class KafkaMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         KafkaMessage that = (KafkaMessage) o;
-        return Objects.equals(key, that.key) &&
-                Arrays.equals(value, that.value);
+        return Arrays.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, value);
+        return Objects.hash(value);
     }
 }

--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/metrics/ForwarderEventSender.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/metrics/ForwarderEventSender.java
@@ -19,7 +19,7 @@ public class ForwarderEventSender {
 
     public void sendAsync(Long timestamp, Object event) {
         try {
-            kafkaService.sendRecordAsync(hostname, ProtocolMessage.create(timestamp, header, event));
+            kafkaService.sendRecordAsync(ProtocolMessage.create(timestamp, header, event), false);
         } catch (SerializationException | TypeMarkerException e) {
             PrometheusHttpMetrics.EVENTS_IN_ERROR.inc();
         }

--- a/forwarder/src/main/resources/server.properties
+++ b/forwarder/src/main/resources/server.properties
@@ -14,3 +14,5 @@ retries=3
 
 # Prometheus configuration
 prometheus.port=31001
+
+broadcasted.message.types=APPLICATION_EVENT

--- a/forwarder/src/main/resources/server.properties
+++ b/forwarder/src/main/resources/server.properties
@@ -14,5 +14,3 @@ retries=3
 
 # Prometheus configuration
 prometheus.port=31001
-
-broadcasted.message.types=APPLICATION_EVENT

--- a/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/CloseHandlerTest.java
+++ b/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/CloseHandlerTest.java
@@ -21,6 +21,7 @@ import sun.misc.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Random;
 
 public class CloseHandlerTest {
@@ -31,7 +32,7 @@ public class CloseHandlerTest {
     @Before
     public void executedBeforeEach() {
         CloseHandler closeHandler = new CloseHandler();
-        EventHandler eventHandler = new EventHandler();
+        EventHandler eventHandler = new EventHandler(Collections.emptySet());
         channel.get().pipeline().addLast(closeHandler).addLast(eventHandler);
 
         GarmadonSerialization.register(TestEvent.class, Integer.MAX_VALUE, "TestEvent", event -> event.bytes, TestEvent::new);
@@ -58,7 +59,7 @@ public class CloseHandlerTest {
         Assert.assertTrue(channel.get().writeInbound(input));
         Assert.assertTrue(channel.get().finish());
 
-        KafkaMessage expected = new KafkaMessage("app_id", raw);
+        KafkaMessage expected = new KafkaMessage(raw);
         Assert.assertEquals(expected, channel.get().readInbound());
 
         // Check that we sendAsync the end event

--- a/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/EventHandlerTest.java
+++ b/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/EventHandlerTest.java
@@ -43,7 +43,7 @@ public class EventHandlerTest {
     }
 
     @Test
-    public void EventHandler_should_read_non_braodcasted_event() throws TypeMarkerException, SerializationException {
+    public void EventHandler_should_read_non_broadcasted_event() throws TypeMarkerException, SerializationException {
         Header header = Header.newBuilder()
                 .withHostname("hostname")
                 .withId("app_id")

--- a/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/EventHandlerTest.java
+++ b/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/EventHandlerTest.java
@@ -2,25 +2,23 @@ package com.criteo.hadoop.garmadon.forwarder.handler;
 
 
 import com.criteo.hadoop.garmadon.forwarder.handler.junit.rules.WithEmbeddedChannel;
+import com.criteo.hadoop.garmadon.forwarder.message.BroadCastedKafkaMessage;
 import com.criteo.hadoop.garmadon.forwarder.message.KafkaMessage;
 import com.criteo.hadoop.garmadon.protocol.ProtocolMessage;
 import com.criteo.hadoop.garmadon.schema.events.Header;
 import com.criteo.hadoop.garmadon.schema.exceptions.SerializationException;
 import com.criteo.hadoop.garmadon.schema.exceptions.TypeMarkerException;
 import com.criteo.hadoop.garmadon.schema.serialization.GarmadonSerialization;
-import com.google.protobuf.GeneratedMessage;
-import com.google.protobuf.Message;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import sun.misc.IOUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Random;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static junit.framework.TestCase.assertFalse;
 
@@ -29,16 +27,23 @@ public class EventHandlerTest {
     @Rule
     public WithEmbeddedChannel channel = new WithEmbeddedChannel();
 
+    private Set<Integer> broadcastedTypes;
+    private int broadCastedType1 = 10;
+    private int broadCastedType2 = 20;
+
     @Before
     public void executedBeforeEach() {
-        EventHandler eventHandler = new EventHandler();
+        broadcastedTypes = new HashSet<>();
+        broadcastedTypes.add(broadCastedType1);
+        broadcastedTypes.add(broadCastedType2);
+        EventHandler eventHandler = new EventHandler(broadcastedTypes);
         channel.get().pipeline().addLast(eventHandler);
 
         GarmadonSerialization.register(TestEvent.class, Integer.MAX_VALUE, "TestEvent", event -> event.bytes, TestEvent::new);
     }
 
     @Test
-    public void EventHandler_should_read_event_according_top_protocol() throws TypeMarkerException, SerializationException {
+    public void EventHandler_should_read_non_braodcasted_event() throws TypeMarkerException, SerializationException {
         Header header = Header.newBuilder()
                 .withHostname("hostname")
                 .withId("app_id")
@@ -57,7 +62,35 @@ public class EventHandlerTest {
         Assert.assertTrue(channel.get().writeInbound(input));
         Assert.assertTrue(channel.get().finish());
 
-        KafkaMessage expected = new KafkaMessage("app_id", raw);
+        KafkaMessage expected = new KafkaMessage(raw);
+        Assert.assertEquals(expected, channel.get().readInbound());
+        //check there is nothing more
+        Assert.assertNull(channel.get().readInbound());
+    }
+
+    @Test
+    public void EventHandler_should_read_broadcasted_event() throws TypeMarkerException, SerializationException {
+        GarmadonSerialization.register(TestEvent.class, broadCastedType2, "TestEvent", event -> event.bytes, TestEvent::new);
+
+        Header header = Header.newBuilder()
+            .withHostname("hostname")
+            .withId("app_id")
+            .withApplicationID("app_id")
+            .withAttemptID("app_attempt_id")
+            .withApplicationName("app_name")
+            .withContainerID("container_id")
+            .withUser("user")
+            .withPid("pid")
+            .build();
+
+
+        byte[] raw = ProtocolMessage.create(System.currentTimeMillis(), header.serialize(), new TestEvent(100));
+
+        ByteBuf input = Unpooled.wrappedBuffer(raw);
+        Assert.assertTrue(channel.get().writeInbound(input));
+        Assert.assertTrue(channel.get().finish());
+
+        BroadCastedKafkaMessage expected = new BroadCastedKafkaMessage(raw);
         Assert.assertEquals(expected, channel.get().readInbound());
         //check there is nothing more
         Assert.assertNull(channel.get().readInbound());

--- a/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/KafkaHandlerTest.java
+++ b/forwarder/src/test/java/com/criteo/hadoop/garmadon/forwarder/handler/KafkaHandlerTest.java
@@ -2,6 +2,7 @@ package com.criteo.hadoop.garmadon.forwarder.handler;
 
 import com.criteo.hadoop.garmadon.forwarder.handler.junit.rules.WithEmbeddedChannel;
 import com.criteo.hadoop.garmadon.forwarder.handler.junit.rules.WithMockedKafkaService;
+import com.criteo.hadoop.garmadon.forwarder.message.BroadCastedKafkaMessage;
 import com.criteo.hadoop.garmadon.forwarder.message.KafkaMessage;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,10 +31,22 @@ public class KafkaHandlerTest {
         byte[] raw = new byte[230];
         new Random().nextBytes(raw);
 
-        KafkaMessage incomingMsg = new KafkaMessage("application_1517483736011_1079", raw);
+        KafkaMessage incomingMsg = new KafkaMessage(raw);
 
         channel.get().writeInbound(incomingMsg);
 
-        verify(kafkaService.mock()).sendRecordAsync("application_1517483736011_1079", raw);
+        verify(kafkaService.mock()).sendRecordAsync(raw, false);
+    }
+
+    @Test
+    public void KafkaHandler_should_send_a_broadcasted_event_when_receiving_BroadCastedKafkaMessage() {
+        byte[] raw = new byte[230];
+        new Random().nextBytes(raw);
+
+        BroadCastedKafkaMessage incomingMsg = new BroadCastedKafkaMessage(raw);
+
+        channel.get().writeInbound(incomingMsg);
+
+        verify(kafkaService.mock()).sendRecordAsync(raw, true);
     }
 }

--- a/schema/src/main/java/com/criteo/hadoop/garmadon/schema/serialization/GarmadonSerialization.java
+++ b/schema/src/main/java/com/criteo/hadoop/garmadon/schema/serialization/GarmadonSerialization.java
@@ -45,6 +45,7 @@ public class GarmadonSerialization {
 
     private static HashMap<Class, Integer> classToMarker = new HashMap<>();
     private static HashMap<Integer, String> typeMarkerToName = new HashMap<>();
+    private static HashMap<String, Integer> nameToTypeMarker = new HashMap<>();
 
     static {
         // hadoop events
@@ -113,6 +114,14 @@ public class GarmadonSerialization {
         }
     }
 
+    public static int getMarker(String name) throws TypeMarkerException {
+        if (nameToTypeMarker.containsKey(name)) {
+            return nameToTypeMarker.get(name);
+        } else {
+            throw new TypeMarkerException("cannot find type marker for " + name);
+        }
+    }
+
     public static String getTypeName(int typeMarker) {
         return typeMarkerToName.getOrDefault(typeMarker, "UNKNOWN");
     }
@@ -142,6 +151,7 @@ public class GarmadonSerialization {
         typeMarkerToDeserializer.put(marker, d);
         classToSerializer.put(aClass, s);
         typeMarkerToName.put(marker, name);
+        nameToTypeMarker.put(name, marker);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Sending all events for an application id to all kafka partitions creates a sharding issue and can at worst DDOS a kafka partition master

This commit forces all events to be sent to any partitions. Making so, we lose the possibility to enrich some events with information from other events (such as elastic search reader does).
To cope with this issue, this commit also introduce the possibility to send some specific type of events to all partition.

Sending events to all partitions should be reserved for low frequency events. By default, no event are sent to all partitions.