### PR TITLE
Remove the hostname to producer client-id

### DIFF
--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/Forwarder.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 
 public class Forwarder {
     public static final String PRODUCER_PREFIX_NAME = "garmadon.forwarder";
+    private static final String CLIENT_ID_NAME = PRODUCER_PREFIX_NAME;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Forwarder.class);
 
@@ -73,7 +74,7 @@ public class Forwarder {
      */
     public ChannelFuture run() throws IOException {
         // initialise kafka
-        properties.put(ProducerConfig.CLIENT_ID_CONFIG, PRODUCER_PREFIX_NAME + "." + hostname);
+        properties.put(ProducerConfig.CLIENT_ID_CONFIG, CLIENT_ID_NAME);
         kafkaService = new KafkaService(properties);
 
         // initialize metrics


### PR DESCRIPTION
Kafka server-side quota configuration is only compatible with exact client-id (no regex possible).
PRODUCER_PREFIX_NAME variable is not removed as used in metrics.