### PR TITLE
[HDFS READER] Reduce the amount of Hive queries

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -3,6 +3,7 @@ package com.criteo.hadoop.garmadon.hdfs;
 import com.criteo.hadoop.garmadon.event.proto.*;
 import com.criteo.hadoop.garmadon.hdfs.configurations.HdfsReaderConfiguration;
 import com.criteo.hadoop.garmadon.hdfs.hive.HiveClient;
+import com.criteo.hadoop.garmadon.hdfs.hive.HiveQueryExecutor;
 import com.criteo.hadoop.garmadon.hdfs.kafka.OffsetResetter;
 import com.criteo.hadoop.garmadon.hdfs.kafka.PartitionsPauseStateHandler;
 import com.criteo.hadoop.garmadon.hdfs.monitoring.PrometheusMetrics;
@@ -136,7 +137,8 @@ public class ReaderFactory {
         HiveClient hiveClient = null;
         if (createHiveTable) {
             try {
-                hiveClient = new HiveClient(driverName, hiveJdbcUrl, hiveDatabase, new Path(finalHdfsDir, "hive").toString());
+                hiveClient = new HiveClient(new HiveQueryExecutor(driverName, hiveJdbcUrl, hiveDatabase),
+                    new Path(finalHdfsDir, "hive").toString());
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
@@ -23,7 +23,7 @@ public class HiveClient {
     private final Set<String> createdTables = new HashSet<>();
 
     public HiveClient(HiveQueryExecutor executor, String location) throws SQLException {
-        this.createdPartitions = Collections.newSetFromMap(new LinkedHashMap<Pair<String, String>, Boolean>(){
+        this.createdPartitions = Collections.newSetFromMap(new LinkedHashMap<Pair<String, String>, Boolean>() {
             protected boolean removeEldestEntry(Entry<Pair<String, String>, Boolean> eldest) {
                 return size() > 100;
             }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
@@ -1,7 +1,10 @@
 package com.criteo.hadoop.garmadon.hdfs.hive;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.parquet.schema.MessageType;
@@ -16,10 +19,15 @@ public class HiveClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(HiveClient.class);
 
     private final HiveQueryExecutor executor;
-    private final Set<Pair<String, String>> createdPartitions = new HashSet<>();
+    private final Set<Pair<String, String>> createdPartitions;
     private final Set<String> createdTables = new HashSet<>();
 
     public HiveClient(HiveQueryExecutor executor, String location) throws SQLException {
+        this.createdPartitions = Collections.newSetFromMap(new LinkedHashMap<Pair<String, String>, Boolean>(){
+            protected boolean removeEldestEntry(Entry<Pair<String, String>, Boolean> eldest) {
+                return size() > 100;
+            }
+        });
         this.executor = executor;
         // TODO discover mesos slave to contact
         this.executor.connect();

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
@@ -1,79 +1,51 @@
 package com.criteo.hadoop.garmadon.hdfs.hive;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
-import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.stream.Collectors;
 
 public class HiveClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(HiveClient.class);
 
-    private final String database;
-    private final String jdbcUrl;
-    private Connection connection;
-    private Statement stmt;
+    private final HiveQueryExecutor executor;
+    private final Set<Pair<String, String>> createdPartitions = new HashSet<>();
+    private final Set<String> createdTables = new HashSet<>();
 
-    public HiveClient(String driverName, String jdbcUrl, String database, String location) throws SQLException {
-        try {
-            Class.forName(driverName);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
-        this.database = database;
-        this.jdbcUrl = jdbcUrl;
+    public HiveClient(HiveQueryExecutor executor, String location) throws SQLException {
+        this.executor = executor;
         // TODO discover mesos slave to contact
-        connect();
-        createDatabaseIfAbsent(location);
+        this.executor.connect();
+        this.executor.createDatabaseIfAbsent(location);
     }
 
-    protected void connect() throws SQLException {
-        connection = DriverManager.getConnection(jdbcUrl);
-        stmt = connection.createStatement();
-    }
-
-    protected void execute(String query) throws SQLException {
-        LOGGER.debug("Execute hql: {}", query);
-        int maxAttempts = 5;
-        for (int retry = 1; retry <= maxAttempts; ++retry) {
-            try {
-                stmt.execute(query);
-            } catch (SQLException sqlException) {
-                if (ExceptionUtils.indexOfThrowable(sqlException, TTransportException.class) != -1) {
-                    String exMsg = String.format("Retry connecting to hive (%d/%d)", retry, maxAttempts);
-                    if (retry <= maxAttempts) {
-                        LOGGER.warn(exMsg, sqlException);
-                        try {
-                            Thread.sleep(1000 * retry);
-                            connect();
-                        } catch (Exception ignored) {
-                        }
-                    } else {
-                        LOGGER.error(exMsg, sqlException);
-                        throw sqlException;
-                    }
-                } else {
-                    throw sqlException;
-                }
-            }
+    public void createPartitionIfNotExist(String table, MessageType schema, String partition, String location) throws SQLException {
+        if (partitionAlreadyCreated(partition, table)) {
+            LOGGER.info("Partition day={} on {} already exists, skipping creation", partition, table);
+            return;
         }
+
+        createTableIfNotExist(table, schema, location);
+
+        this.executor.createPartition(table, partition, location);
+
+        registerPartitionCreation(partition, table);
     }
 
-    public void createDatabaseIfAbsent(String location) throws SQLException {
-        String databaseCreation = "CREATE DATABASE IF NOT EXISTS " + database + " COMMENT 'Database for garmadon events' LOCATION '" + location + "'";
-        LOGGER.info("Create database {} if not exists", database);
-        execute(databaseCreation);
-    }
+    @VisibleForTesting
+    public void createTableIfNotExist(String table, MessageType schema, String location) throws SQLException {
+        if (tableAlreadyCreated(table)) {
+            LOGGER.info("Table {} already exists, skipping creation", table);
+            return;
+        }
 
-    protected void createTableIfNotExist(String table, MessageType schema, String location) throws SQLException {
         String hiveSchema = schema.getFields().stream().map(field -> {
             try {
                 return field.getName() + " " + inferHiveType(field);
@@ -82,28 +54,13 @@ public class HiveClient {
             }
         }).collect(Collectors.joining(", "));
 
-        String tableCreation = "CREATE EXTERNAL TABLE IF NOT EXISTS "
-            + database + "." + table
-            + "(" + hiveSchema + ")"
-            + " PARTITIONED BY (day string)"
-            + " STORED AS PARQUET"
-            + " LOCATION '" + location + "'";
-        LOGGER.info("Create table {} if not exists", table);
-        execute(tableCreation);
+        this.executor.createTableIfNotExists(table, hiveSchema, location);
+
+        registerTableCreation(table);
     }
 
-    public void createPartitionIfNotExist(String table, MessageType schema, String partition, String location) throws SQLException {
-        createTableIfNotExist(table, schema, location);
-
-        String partitionCreation = "ALTER TABLE "
-            + database + "." + table
-            + " ADD IF NOT EXISTS PARTITION (day='" + partition + "')"
-            + " LOCATION '" + location + "/day=" + partition + "'";
-        LOGGER.info("Create partition day={} on {} if not exists", partition, table);
-        execute(partitionCreation);
-    }
-
-    protected String inferHiveType(Type field) throws Exception {
+    @VisibleForTesting
+    public String inferHiveType(Type field) throws Exception {
         String fieldHiveType;
 
         switch (field.asPrimitiveType().getPrimitiveTypeName().name()) {
@@ -137,11 +94,22 @@ public class HiveClient {
     }
 
     public void close() throws SQLException {
-        if (stmt != null) stmt.close();
-        if (connection != null) connection.close();
+        executor.close();
     }
 
-    protected Statement getStmt() {
-        return stmt;
+    private boolean partitionAlreadyCreated(String partition, String table) {
+        return createdPartitions.contains(Pair.of(partition, table));
+    }
+
+    private void registerPartitionCreation(String partition, String table) {
+        createdPartitions.add(Pair.of(partition, table));
+    }
+
+    private boolean tableAlreadyCreated(String table) {
+        return createdTables.contains(table);
+    }
+
+    private void registerTableCreation(String table) {
+        createdTables.add(table);
     }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
@@ -10,88 +10,94 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HiveQueryExecutor {
-  private static final Logger LOGGER = LoggerFactory.getLogger(HiveQueryExecutor.class);
-  private final String jdbcUrl;
-  private final String database;
-  private Connection connection;
-  private Statement stmt;
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveQueryExecutor.class);
+    private final String jdbcUrl;
+    private final String database;
+    private Connection connection;
+    private Statement stmt;
 
-  public HiveQueryExecutor(String driverName, String jdbcUrl, String database) {
-    this.database = database;
-    try {
-      Class.forName(driverName);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
+    public HiveQueryExecutor(String driverName, String jdbcUrl, String database) {
+        this.database = database;
+        try {
+            Class.forName(driverName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.jdbcUrl = jdbcUrl;
     }
 
-    this.jdbcUrl = jdbcUrl;
-  }
+    public void createDatabaseIfAbsent(String location) throws SQLException {
+        String databaseCreation =
+            "CREATE DATABASE IF NOT EXISTS " + database + " COMMENT 'Database for garmadon events' LOCATION '"
+                + location + "'";
+        LOGGER.info("Create database {} if not exists", database);
+        execute(databaseCreation);
+    }
 
-  public void createDatabaseIfAbsent(String location) throws SQLException {
-    String databaseCreation = "CREATE DATABASE IF NOT EXISTS " + database + " COMMENT 'Database for garmadon events' LOCATION '" + location + "'";
-    LOGGER.info("Create database {} if not exists", database);
-    execute(databaseCreation);
-  }
+    public void createTableIfNotExists(String table, String hiveSchema, String location) throws SQLException {
+        String tableCreation = "CREATE EXTERNAL TABLE IF NOT EXISTS "
+            + database + "." + table
+            + "(" + hiveSchema + ")"
+            + " PARTITIONED BY (day string)"
+            + " STORED AS PARQUET"
+            + " LOCATION '" + location + "'";
+        LOGGER.info("Create table {} if not exists", table);
+        execute(tableCreation);
+    }
 
-  public void createTableIfNotExists(String table, String hiveSchema, String location) throws SQLException {
-    String tableCreation = "CREATE EXTERNAL TABLE IF NOT EXISTS "
-        + database + "." + table
-        + "(" + hiveSchema + ")"
-        + " PARTITIONED BY (day string)"
-        + " STORED AS PARQUET"
-        + " LOCATION '" + location + "'";
-    LOGGER.info("Create table {} if not exists", table);
-    execute(tableCreation);
-  }
+    public void createPartition(String table, String partition, String location) throws SQLException {
+        String partitionCreation = "ALTER TABLE "
+            + database + "." + table
+            + " ADD IF NOT EXISTS PARTITION (day='" + partition + "')"
+            + " LOCATION '" + location + "/day=" + partition + "'";
+        LOGGER.info("Create partition day={} on {} if not exists", partition, table);
+        execute(partitionCreation);
+    }
 
-  public void createPartition(String table, String partition, String location) throws SQLException {
-    String partitionCreation = "ALTER TABLE "
-        + database + "." + table
-        + " ADD IF NOT EXISTS PARTITION (day='" + partition + "')"
-        + " LOCATION '" + location + "/day=" + partition + "'";
-    LOGGER.info("Create partition day={} on {} if not exists", partition, table);
-    execute(partitionCreation);
-  }
+    public void connect() throws SQLException {
+        connection = DriverManager.getConnection(jdbcUrl);
+        stmt = connection.createStatement();
+    }
 
-  public void connect() throws SQLException {
-    connection = DriverManager.getConnection(jdbcUrl);
-    stmt = connection.createStatement();
-  }
-
-  public void close() throws SQLException {
-    if (stmt != null) stmt.close();
-    if (connection != null) connection.close();
-  }
-
-  public void execute(String query) throws SQLException {
-    LOGGER.debug("Execute hql: {}", query);
-    int maxAttempts = 5;
-    for (int retry = 1; retry <= maxAttempts; ++retry) {
-      try {
-        stmt.execute(query);
-        return;
-      } catch (SQLException sqlException) {
-        if (ExceptionUtils.indexOfThrowable(sqlException, TTransportException.class) != -1) {
-          String exMsg = String.format("Retry connecting to hive (%d/%d)", retry, maxAttempts);
-          if (retry <= maxAttempts) {
-            LOGGER.warn(exMsg, sqlException);
-            try {
-              Thread.sleep(1000 * retry);
-              connect();
-            } catch (Exception ignored) {
-            }
-          } else {
-            LOGGER.error(exMsg, sqlException);
-            throw sqlException;
-          }
-        } else {
-          throw sqlException;
-        }
+    public void close() throws SQLException {
+      if (stmt != null) {
+        stmt.close();
+      }
+      if (connection != null) {
+        connection.close();
       }
     }
-  }
 
-  public Statement getStmt() {
-    return stmt;
-  }
+    public void execute(String query) throws SQLException {
+        LOGGER.debug("Execute hql: {}", query);
+        int maxAttempts = 5;
+        for (int retry = 1; retry <= maxAttempts; ++retry) {
+            try {
+                stmt.execute(query);
+                return;
+            } catch (SQLException sqlException) {
+                if (ExceptionUtils.indexOfThrowable(sqlException, TTransportException.class) != -1) {
+                    String exMsg = String.format("Retry connecting to hive (%d/%d)", retry, maxAttempts);
+                    if (retry <= maxAttempts) {
+                        LOGGER.warn(exMsg, sqlException);
+                        try {
+                            Thread.sleep(1000 * retry);
+                            connect();
+                        } catch (Exception ignored) {
+                        }
+                    } else {
+                        LOGGER.error(exMsg, sqlException);
+                        throw sqlException;
+                    }
+                } else {
+                    throw sqlException;
+                }
+            }
+        }
+    }
+
+    public Statement getStmt() {
+        return stmt;
+    }
 }

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HiveQueryExecutor {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(HiveQueryExecutor.class);
     private final String jdbcUrl;
     private final String database;
@@ -61,12 +62,12 @@ public class HiveQueryExecutor {
     }
 
     public void close() throws SQLException {
-      if (stmt != null) {
-        stmt.close();
-      }
-      if (connection != null) {
-        connection.close();
-      }
+        if (stmt != null) {
+            stmt.close();
+        }
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     public void execute(String query) throws SQLException {

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutor.java
@@ -1,0 +1,97 @@
+package com.criteo.hadoop.garmadon.hdfs.hive;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HiveQueryExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HiveQueryExecutor.class);
+  private final String jdbcUrl;
+  private final String database;
+  private Connection connection;
+  private Statement stmt;
+
+  public HiveQueryExecutor(String driverName, String jdbcUrl, String database) {
+    this.database = database;
+    try {
+      Class.forName(driverName);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+
+    this.jdbcUrl = jdbcUrl;
+  }
+
+  public void createDatabaseIfAbsent(String location) throws SQLException {
+    String databaseCreation = "CREATE DATABASE IF NOT EXISTS " + database + " COMMENT 'Database for garmadon events' LOCATION '" + location + "'";
+    LOGGER.info("Create database {} if not exists", database);
+    execute(databaseCreation);
+  }
+
+  public void createTableIfNotExists(String table, String hiveSchema, String location) throws SQLException {
+    String tableCreation = "CREATE EXTERNAL TABLE IF NOT EXISTS "
+        + database + "." + table
+        + "(" + hiveSchema + ")"
+        + " PARTITIONED BY (day string)"
+        + " STORED AS PARQUET"
+        + " LOCATION '" + location + "'";
+    LOGGER.info("Create table {} if not exists", table);
+    execute(tableCreation);
+  }
+
+  public void createPartition(String table, String partition, String location) throws SQLException {
+    String partitionCreation = "ALTER TABLE "
+        + database + "." + table
+        + " ADD IF NOT EXISTS PARTITION (day='" + partition + "')"
+        + " LOCATION '" + location + "/day=" + partition + "'";
+    LOGGER.info("Create partition day={} on {} if not exists", partition, table);
+    execute(partitionCreation);
+  }
+
+  public void connect() throws SQLException {
+    connection = DriverManager.getConnection(jdbcUrl);
+    stmt = connection.createStatement();
+  }
+
+  public void close() throws SQLException {
+    if (stmt != null) stmt.close();
+    if (connection != null) connection.close();
+  }
+
+  public void execute(String query) throws SQLException {
+    LOGGER.debug("Execute hql: {}", query);
+    int maxAttempts = 5;
+    for (int retry = 1; retry <= maxAttempts; ++retry) {
+      try {
+        stmt.execute(query);
+        return;
+      } catch (SQLException sqlException) {
+        if (ExceptionUtils.indexOfThrowable(sqlException, TTransportException.class) != -1) {
+          String exMsg = String.format("Retry connecting to hive (%d/%d)", retry, maxAttempts);
+          if (retry <= maxAttempts) {
+            LOGGER.warn(exMsg, sqlException);
+            try {
+              Thread.sleep(1000 * retry);
+              connect();
+            } catch (Exception ignored) {
+            }
+          } else {
+            LOGGER.error(exMsg, sqlException);
+            throw sqlException;
+          }
+        } else {
+          throw sqlException;
+        }
+      }
+    }
+  }
+
+  public Statement getStmt() {
+    return stmt;
+  }
+}

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutorTest.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveQueryExecutorTest.java
@@ -1,0 +1,56 @@
+package com.criteo.hadoop.garmadon.hdfs.hive;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HiveQueryExecutorTest {
+    private Path hdfsTemp;
+    private SimpleHiveServer hiveServer;
+
+    @Before
+    public void setup() throws IOException {
+        hdfsTemp = Files.createTempDirectory("hdfs");
+        hiveServer = new SimpleHiveServer();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        try {
+            hiveServer.cleanup();
+        }
+        catch (IOException e) {
+            // Nothing
+        }
+
+        FileUtils.deleteDirectory(hdfsTemp.toFile());
+    }
+
+    @Test
+    public void shouldReconnectOnTTransportException() throws Exception {
+        HiveQueryExecutor executor = spy(new HiveQueryExecutor(
+            SimpleHiveServer.DRIVER_NAME, hiveServer.getJdbcString(), "garmadon"));
+
+        executor.connect();
+        executor.createDatabaseIfAbsent(hdfsTemp + "/garmadon_database");
+
+        hiveServer.stop();
+
+        // Ignore exception as hiveserver2 is down and we are testing that connect method is well called multiple times
+        try {
+            executor.createDatabaseIfAbsent(hdfsTemp + "/garmadon_database");
+        } catch (SQLException ignored) {
+        }
+
+        verify(executor, times(6)).connect();
+    }
+}

--- a/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/hive/SimpleHiveServer.java
+++ b/readers/hdfs/src/test/java/com/criteo/hadoop/garmadon/hdfs/hive/SimpleHiveServer.java
@@ -1,0 +1,48 @@
+package com.criteo.hadoop.garmadon.hdfs.hive;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.server.HiveServer2;
+
+public class SimpleHiveServer {
+    public static final String DRIVER_NAME = "org.apache.hive.jdbc.HiveDriver";
+    private final Path derbyDBPath;
+    private final HiveServer2 hiveServer2;
+    private final String port;
+
+    SimpleHiveServer() throws IOException {
+        derbyDBPath = Files.createTempDirectory("derbyDB");
+
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HiveConf.ConfVars.METASTORECONNECTURLKEY.toString(), "jdbc:derby:;databaseName=" +
+            derbyDBPath.toString() + "/derbyDB" + ";create=true");
+
+        ServerSocket s = new ServerSocket(0);
+        port = String.valueOf(s.getLocalPort());
+        hiveConf.set(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_PORT.varname, port);
+        // Required to avoid NoSuchMethodError org.apache.hive.service.cli.operation.LogDivertAppender.setWriter
+        hiveConf.set(HiveConf.ConfVars.HIVE_SERVER2_LOGGING_OPERATION_ENABLED.varname, "false");
+
+        hiveServer2 = new HiveServer2();
+        hiveServer2.init(hiveConf);
+        s.close();
+        hiveServer2.start();
+    }
+
+    public String getJdbcString() {
+        return "jdbc:hive2://localhost:" + port;
+    }
+
+    public void cleanup() throws IOException {
+        stop();
+        FileUtils.deleteDirectory(derbyDBPath.toFile());
+    }
+
+    public void stop() {
+        hiveServer2.stop();
+    }
+}


### PR DESCRIPTION
* There was a bug executing succesful queries 5 times
* Execution of create table and create partition queries is now cached so that no two identical two of them will be performed.
Limitation is this is in memory, but this should be sufficient.
* Splitted HiveClient between execution and abstraction levels; execute as well as some methods that should be private are still
in the public interface of HiveQueryExecutor because fixing this would cause scope creep