### PR TITLE
Allow kafka topic name to be loaded from forwarder config file

### DIFF
--- a/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
+++ b/forwarder/src/main/java/com/criteo/hadoop/garmadon/forwarder/kafka/KafkaService.java
@@ -16,7 +16,7 @@ public class KafkaService {
     private final String topic;
 
     public KafkaService(Properties properties) {
-        this.topic = "garmadon";
+        this.topic = properties.getProperty("topic", "garmadon");
         this.producer = new KafkaProducer<>(properties);
     }
 


### PR DESCRIPTION
Default kafka topic for garmadon forwarder is 'garmadon'. This can
now be overwritten with the 'topic' key in server.properties of
the forwarder.