### PR TITLE
Adapt CREATE TABLE statement to Hive2

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/hive/HiveClient.java
@@ -56,7 +56,7 @@ public class HiveClient {
 
         String hiveSchema = schema.getFields().stream().map(field -> {
             try {
-                return field.getName() + " " + inferHiveType(field);
+                return "`" + field.getName() + "` " + inferHiveType(field);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Hive2 has keywords that need backticks quoting
More info in https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords