### PR TITLE
Fix the pentaho dependency for the maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,14 @@
             <id>cloudera</id>
             <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
         </repository>
+	<repository>
+            <id>pentaho</id>
+	    <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+        </repository>    
     </repositories>
 
     <properties>
-	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <garmadon.version>1.4.0</garmadon.version>
         <hadoop.version>2.6.0-cdh5.11.0</hadoop.version>
         <hive.version>1.1.0-cdh5.11.0</hive.version>


### PR DESCRIPTION
Because during maven build:
[ERROR] Failed to execute goal on project garmadon-readers-hdfs:
Could not resolve dependencies for project com.criteo.java:garmadon-readers-hdfs:jar:1.4.0:
Failure to find org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde
in https://repository.cloudera.com/artifactory/cloudera-repos/

https://repository.cloudera.com/artifactory/cloudera-repos/org/pentaho/pentaho-aggdesign[…]5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom gives 404

See official pentaho project:
https://github.com/pentaho/pentaho-aggdesigner/blob/master/pom.xml

Added a new maven repository to pull artifacts