### PR TITLE
Update vulnerable dependency: com.fasterxml.jackson.core:jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <guava.version>20.0</guava.version>
         <parquet-protobuf.version>1.10.1</parquet-protobuf.version>
         <protobuf-dynamic.version>1.0.0</protobuf-dynamic.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <commons-io.version>2.6</commons-io.version>
         <flink.version>1.6.4</flink.version>
         <prestodb.version>0.217</prestodb.version>


### PR DESCRIPTION

Hi! We spot a vulnerable dependency in your project, which might threaten your software. We also found another project that uses the same vulnerable dependency in a similar way as you did, and they have upgraded the dependency. We, thus, believe that your project is highly possible to be affected by this vulnerability similarly. The following shows the detailed information. 

## Vulnerability description
+ CVE: **CVE-2019-16943**
+ Vulnerable dependency: **com.fasterxml.jackson.core:jackson-databind:2.9.8**
+ Vulnerable function: **com.fasterxml.jackson.databind.JavaType:isEnumType()**
+ Invocation Path: 
```java
com.criteo.hadoop.garmadon.reader.configurations.ReaderConfiguration:loadConfig(java.lang.Class,java.lang.String)
 ⬇️ 
com.fasterxml.jackson.databind.ObjectMapper:readValue(java.io.InputStream,java.lang.Class)
 ⬇️ 
...
 ⬇️ 
com.fasterxml.jackson.databind.JavaType:isEnumType()
```

## Upgrade example
Another project also used the same dependency with a similar invocation path, and they have taken actions to resolve this issue.
+ Project: https://github.com/docusign/docusign-esign-java-client
+ Action commit:https://github.com/docusign/docusign-esign-java-client/commit/b9140c772d95f1f6aadb4d074fd9af1ae08ae6b1
+ Invocation Path:
```java
com.docusign.esign.client.ApiClient:generateAccessToken(java.lang.String,java.lang.String,java.lang.String)
 ⬇️ 
com.fasterxml.jackson.databind.ObjectMapper:readValue(java.io.InputStream,java.lang.Class)
 ⬇️ 
...
 ⬇️ 
com.fasterxml.jackson.databind.JavaType:isEnumType()
```

Therefore, you might also need to upgrade this dependency. Hope this can help you! 😄
