### PR TITLE
Fix JvmStatisticsHeap serialization to Parquet

### DIFF
--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/EventsWithHeader.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/EventsWithHeader.java
@@ -1,6 +1,7 @@
 package com.criteo.hadoop.garmadon.hdfs;
 
 import com.criteo.hadoop.garmadon.event.proto.*;
+import com.criteo.hadoop.garmadon.hdfs.proto.JVMStatisticsExplodedProtos;
 import com.criteo.hadoop.garmadon.protobuf.ProtoConcatenator;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
@@ -20,9 +21,9 @@ final public class EventsWithHeader {
         }
     }
 
-    public static abstract class JvmStatsEvent implements Message {
+    public static abstract class JvmStatisticsHeap implements Message {
         public static Descriptors.Descriptor getDescriptor() throws Descriptors.DescriptorValidationException {
-            return descriptorForTypeWithHeader(JVMStatisticsEventsProtos.JVMStatisticsData.getDescriptor());
+            return descriptorForTypeWithHeader(JVMStatisticsExplodedProtos.JvmStatisticsHeap.getDescriptor());
         }
     }
 

--- a/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
+++ b/readers/hdfs/src/main/java/com/criteo/hadoop/garmadon/hdfs/ReaderFactory.java
@@ -128,7 +128,7 @@ public class ReaderFactory {
             out,
             GarmadonSerialization.TypeMarker.JVMSTATS_EVENT,
                 "jvmstats_heap_event",
-            JVMStatisticsExplodedProtos.JvmStatisticsHeap.class,
+            EventsWithHeader.JvmStatisticsHeap.class,
             JVMStatisticsExplodedProtos.JvmStatisticsHeap.newBuilder(),
             body -> {
                 JVMStatisticsEventsProtos.JVMStatisticsData jvmStatisticsData = (JVMStatisticsEventsProtos.JVMStatisticsData) body;


### PR DESCRIPTION
The class requires to have also the header fields