### PR TITLE
Fix ContainerHeader for Spark3

### DIFF
--- a/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/ContainerHeader.java
+++ b/agent/src/main/java/com/criteo/hadoop/garmadon/agent/headers/ContainerHeader.java
@@ -60,6 +60,7 @@ public final class ContainerHeader {
                 component = Component.APP_MASTER;
                 break;
             case "org.apache.spark.executor.CoarseGrainedExecutorBackend":
+            case "org.apache.spark.executor.YarnCoarseGrainedExecutorBackend":
                 framework = Framework.SPARK;
                 component = Component.EXECUTOR;
                 try {


### PR DESCRIPTION
The main class of the executors is now YarnCoarseGrainedExecutorBackend