### PR TITLE
Do not send exception for missing Spark Version

### DIFF
--- a/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/utils/SparkRuntime.java
+++ b/jvm-statistics/src/main/java/com/criteo/hadoop/garmadon/jvm/utils/SparkRuntime.java
@@ -5,67 +5,39 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 public final class SparkRuntime {
-    private static final Version VERSION = computeVersion();
+    private static final String VERSION = computeVersion();
 
     private SparkRuntime() {
     }
 
-    public static String getVersion() throws RuntimeException {
-        if (VERSION.versionNumber == null) {
-            throw new RuntimeException("Could not find Spark version. Is this a Spark application?", VERSION.throwable);
-        }
-        return VERSION.versionNumber;
+    public static String getVersion() {
+        return VERSION;
     }
 
-    static Version computeVersion() {
+    static String computeVersion() {
         try {
             return computeSpark32Version();
         } catch (Throwable e) {
             try {
                 return computeSpark35Version();
             } catch (Throwable t) {
-                return new Version(t);
+                return "unknown";
             }
         }
     }
 
-    private static Version computeSpark32Version() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+    private static String computeSpark32Version() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
         Class<?> clazz = Class.forName("org.apache.spark.package$SparkBuildInfo$");
         Field moduleFIeld = clazz.getField("MODULE$");
         Object instance = moduleFIeld.get(null);
         Field versionField = clazz.getDeclaredField("spark_version");
         versionField.setAccessible(true);
-        String version = (String) versionField.get(instance);
-        return new Version(version);
+        return (String) versionField.get(instance);
     }
 
-    private static Version computeSpark35Version() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    private static String computeSpark35Version() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Class<?> clazz = Class.forName("org.apache.spark.SparkBuildInfo");
         Method versionMethod = clazz.getDeclaredMethod("spark_version");
-        String version = (String) versionMethod.invoke(null);
-        return new Version(version);
-    }
-
-    final static class Version {
-        private final String versionNumber;
-        private final Throwable throwable;
-
-        private Version(String versionNumber) {
-            this.versionNumber = versionNumber;
-            this.throwable = null;
-        }
-
-        private Version(Throwable throwable) {
-            this.versionNumber = null;
-            this.throwable = throwable;
-        }
-
-        public String getVersionNumer() {
-            return versionNumber;
-        }
-
-        public Throwable getThrowable() {
-            return throwable;
-        }
+        return (String) versionMethod.invoke(null);
     }
 }


### PR DESCRIPTION
Do not send exception when failing to retrieve Spark version, send "unknown" instead.